### PR TITLE
fix: whitespace in network selection

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -156,11 +156,11 @@ run() {
     shopt -s nocasematch
     select opt in "${options[@]}"; do
         case "$REPLY" in
-            1|simnet) network="simnet"
+            1|" 1"|" 1 "|"1 "|simnet|" simnet"|" simnet "|"simnet ") network="simnet"
                 break;;
-            2|testnet) network="testnet"
+            2|" 2"|" 2 "|"2 "|testnet|" testnet"|" testnet "|"testnet ") network="testnet"
                 break;;
-            3|mainnet) network="mainnet"
+            3|" 3"|" 3 "|"3 "|mainnet|" mainnet"|" mainnet "|"mainnet ") network="mainnet"
                 echo "Comming soon..."
                 ;;
             *) echo "Invalid option: \"$REPLY\"";;


### PR DESCRIPTION
Closes https://github.com/ExchangeUnion/xud-docker/issues/70.

Still not sure what causes the additional white space on first run of the script and this solution is not very elegant, but fixes it for now.