### PR TITLE
fix: raiden hashresolver

### DIFF
--- a/images/xud/Dockerfile
+++ b/images/xud/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:lts-alpine AS builder
 #RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.nju.edu.cn/' /etc/apk/repositories
 #RUN npm config set registry http://172.17.0.1:7000/repository/npm/
-ARG branch=master
+ARG branch=feat/resolver-interface
 #RUN apk add --no-cache git rsync python bash make alpine-sdk
 #RUN apk add --no-cache git rsync python bash make g++
 # Use pure JS implemented secp256k1 bindings

--- a/images/xud/xud.conf
+++ b/images/xud/xud.conf
@@ -39,6 +39,7 @@ nomatching = false
 nosanityswaps = true
 
 [http]
+host = "0.0.0.0"
 port = 8887
 
 [lnd.BTC]

--- a/xud-simnet/docker-compose.yml
+++ b/xud-simnet/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     command: >
       --keystore-path /root/.raiden/keystore
       --accept-disclaimer
+      --resolver-endpoint http://xud:8887/resolveraiden
       --eth-rpc-endpoint 35.231.222.142:8546
       --network-id 4321
       --password-file /root/.raiden/password.txt


### PR DESCRIPTION
In this commit we expose xud's raiden hashresolver endpoint and specify
the exposed endpoint in raiden's configuration so that it knows where to
resolve external hashes.