### PR TITLE
fix(raiden): add missing resolver-endpoint config

### DIFF
--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     ports:
       - 8885:8885
       - 8886:8886
+      - 8887:8887
   
   geth:
     image: exchangeunion/geth:1.8.27
@@ -133,6 +134,7 @@ services:
       - NETWORK=mainnet
     command: >
       --keystore-path /root/.ethereum/testnet/keystore
+      --resolver-endpoint http://xud:8887/resolveraiden
       --accept-disclaimer
       --eth-rpc-endpoint http://geth:8545
       --network-id 0

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -124,6 +124,7 @@ services:
     command: >
       --keystore-path /root/.ethereum/keys/ropsten
       --accept-disclaimer
+      --resolver-endpoint http://xud:8887/resolveraiden
       --eth-rpc-endpoint parity:8545
       --network-id ropsten
       --password-file /root/.ethereum/passphrase.txt


### PR DESCRIPTION
In this commit we're adding the missing raiden `resolver-endpoint` config flag to testnet and mainnet.