### PR TITLE
fix: set LC_NUMERIC for printing sync percentage

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -32,7 +32,7 @@ status_text() {
             local x=`echo "$1/$2*100" | bc -l`
             local y=`echo "$x*100/1" | bc`
             local z=`echo "$y/100" | bc -l`
-            printf "Syncing %.2f%% (%d/%d)\n" $z $1 $2
+            LC_NUMERIC="en_US.UTF-8" printf "Syncing %.2f%% (%d/%d)\n" $z $1 $2
         fi
     fi
 }


### PR DESCRIPTION
Closes #110

Looks like the `printf: 4.34000000000000000000: invalid number` errors were caused by an invalid locale (for example `LC_NUMERIC=de_AT.UTF-8`) that doesn't know how to handle these numbers that use a dot instead of a comma.