### PR TITLE
chore: remove default currencies and pairs logic

### DIFF
--- a/images/xud-simnet/entrypoint.sh
+++ b/images/xud-simnet/entrypoint.sh
@@ -11,46 +11,15 @@ check_xud() {
     ! [ -z "$lndbtc_ok" ] && ! [ -z "$lndltc_ok" ] && ! [ -z "$raiden_ok" ]
 }
 
-set_weth() {
-    while ! check_xud; do
-        sleep 3
-    done
-
-    pairs=`xucli listpairs --json|grep "/" |wc -l`
-
-    if [ $pairs -eq 4 ] ; then
-	    return
-    fi
-
-    WETH="0x9F50cEA29307d7D91c5176Af42f3aB74f0190dD3"
-    DAI="0x76671A2831Dc0aF53B09537dea57F1E22899655d"
-
-    xucli removepair WETH/BTC > /dev/null 2>&1
-    xucli removepair BTC/DAI > /dev/null 2>&1
-    xucli removepair LTC/DAI > /dev/null 2>&1
-
-    xucli removecurrency WETH > /dev/null 2>&1
-    xucli removecurrency DAI > /dev/null 2>&1
-
-    xucli addcurrency WETH Raiden 18 $WETH > /dev/null 2>&1
-    xucli addcurrency DAI Raiden 18 $DAI > /dev/null 2>&1
-
-    xucli addpair WETH BTC > /dev/null 2>&1
-    xucli addpair BTC DAI > /dev/null 2>&1
-    xucli addpair LTC DAI > /dev/null 2>&1
-
-    xucli listpairs
-}
-
 write_config() {
 	cp /tmp/xud.conf ~/.xud
-	
+
 	hn="$(hostname)"
 	n="${hn:3}"
 
-	if [[ -z $n ]]; then 
+	if [[ -z $n ]]; then
     	insid="0"
-	else 
+	else
     	insid="$n"
 	fi
 
@@ -71,9 +40,5 @@ while ! [ -e "/root/.lndltc/data/chain/litecoin/$NETWORK/admin.macaroon" ]; do
     echo "Waiting for lndltc admin.macaroon"
     sleep 3
 done
-
-if [ "$NETWORK" = "simnet" ]; then
-    set_weth &
-fi
 
 ./bin/xud $@

--- a/images/xud/entrypoint.sh
+++ b/images/xud/entrypoint.sh
@@ -11,46 +11,15 @@ check_xud() {
     ! [ -z "$lndbtc_ok" ] && ! [ -z "$lndltc_ok" ] && ! [ -z "$raiden_ok" ]
 }
 
-set_weth() {
-    while ! check_xud; do
-        sleep 3
-    done
-
-    pairs=`xucli listpairs --json|grep "/" |wc -l`
-
-    if [ $pairs -eq 4 ] ; then
-	    return
-    fi
-
-    WETH="0x9F50cEA29307d7D91c5176Af42f3aB74f0190dD3"
-    DAI="0x76671A2831Dc0aF53B09537dea57F1E22899655d"
-
-    xucli removepair WETH/BTC > /dev/null 2>&1
-    xucli removepair BTC/DAI > /dev/null 2>&1
-    xucli removepair LTC/DAI > /dev/null 2>&1
-
-    xucli removecurrency WETH > /dev/null 2>&1
-    xucli removecurrency DAI > /dev/null 2>&1
-
-    xucli addcurrency WETH Raiden 18 $WETH > /dev/null 2>&1
-    xucli addcurrency DAI Raiden 18 $DAI > /dev/null 2>&1
-
-    xucli addpair WETH BTC > /dev/null 2>&1
-    xucli addpair BTC DAI > /dev/null 2>&1
-    xucli addpair LTC DAI > /dev/null 2>&1
-
-    xucli listpairs
-}
-
 write_config() {
 	cp /tmp/xud.conf ~/.xud
-	
+
 	hn="$(hostname)"
 	n="${hn:3}"
 
-	if [[ -z $n ]]; then 
+	if [[ -z $n ]]; then
     	insid="0"
-	else 
+	else
     	insid="$n"
 	fi
 
@@ -71,9 +40,5 @@ while ! [ -e "/root/.lndltc/data/chain/litecoin/$NETWORK/admin.macaroon" ]; do
     echo "Waiting for lndltc admin.macaroon"
     sleep 3
 done
-
-if [ "$NETWORK" = "simnet" ]; then
-    set_weth &
-fi
 
 ./bin/xud $@


### PR DESCRIPTION
This PR removes the logic that handles setting the default currencies and pairs for simnet. This logic is now redundant as it will be handled on xud level.