### PR TITLE
chore: update Bitcoin Core version

### DIFF
--- a/images/versions.ini
+++ b/images/versions.ini
@@ -7,7 +7,7 @@ python = 3.7-alpine3.10
 node = lts-alpine ; node 10, alpine 3.9
 
 [application]
-bitcoind = 0.17.1
+bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = 0.7.1-beta
 geth = 1.8.27

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   bitcoind:
-    image: exchangeunion/bitcoind:0.18.0
+    image: exchangeunion/bitcoind:0.18.1
     # Let generated "rpc.cert" has "btcd" domain name,
     # or it will deny lnd rpc connections
     hostname: bitcoind

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   bitcoind:
-    image: exchangeunion/bitcoind:0.17.1
+    image: exchangeunion/bitcoind:0.18.1
     hostname: bitcoind
     environment:
       - NETWORK=testnet


### PR DESCRIPTION
This PR updates the Bitcoin Core version to `0.18.1`. The latest LND version supports this Bitcoin Core version, therefore this update is possible now