### PR TITLE
feat: this adds the flag --cache=1024 to geth for testnet & mainnet

### DIFF
--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       --rpc
       --rpcapi eth,net,web3,txpool,personal,admin
       --rpcvhosts=*
+      --cache=1024
     volumes: 
       - ./data/geth:/root/.ethereum
     logging: *default-logging

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       --testnet
       --rpcapi eth,net,web3,txpool,personal,admin
       --rpcvhosts=*
+      --cache=1024
     volumes: 
       - ./data/geth:/root/.ethereum
     logging: *default-logging


### PR DESCRIPTION
this adds the flag --cache=1024 to geth for testnet & mainnet. 1024 is the [default value](https://geth.ethereum.org/interface/Command-Line-Options) and the reason to add this flag is to point users to it from the docs to manually change this value for a faster sync