### PR TITLE
fix: missing docker-compose config

### DIFF
--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.6"
+
 x-logging:
   &default-logging
   options:

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -1,3 +1,10 @@
+version: "3.6"
+
+x-logging:
+  &default-logging
+  options:
+    max-size: '20m'
+    max-file: '5'
   driver: json-file
 
 services:


### PR DESCRIPTION
This commit re-adds missing docker-compose config that was accidentally
removed in https://github.com/ExchangeUnion/xud-docker/commit/d4ce1a3bf5f7e39da0a79d4fade412d0cc6831d7