### PR TITLE
chore: move raiden keystore

### DIFF
--- a/images/raiden/entrypoint.sh
+++ b/images/raiden/entrypoint.sh
@@ -3,18 +3,15 @@
 set -euo pipefail
 shopt -s expand_aliases
 
+#shellcheck disable=SC1091
 source /opt/venv/bin/activate
 
-XUD_DIR="/root/.xud"
-case $NETWORK in
-testnet)
-  KEYSTORE_DIR="$XUD_DIR/keystore"
-  ;;
-mainnet)
-  KEYSTORE_DIR="$XUD_DIR/keystore"
-  ;;
-esac
 RAIDEN_DIR="$HOME/.raiden"
+KEYSTORE_DIR="$RAIDEN_DIR/keystore"
+
+if [[ ! -e $RAIDEN_DIR/passphrase.txt ]]; then
+  touch "$RAIDEN_DIR/passphrase.txt"
+fi
 
 function geth_ready() {
   curl -sf -o /dev/null -X POST -H 'Content-Type: application/json' \
@@ -31,7 +28,7 @@ function get_addr() {
 }
 
 while [[ ! -e "$KEYSTORE_DIR" || ! $(find "$KEYSTORE_DIR" -maxdepth 1 -type f | wc -l) -gt 0 ]]; do
-  echo "Waiting for geth keystore"
+  echo "Waiting for keystore to be generated"
   sleep 3
 done
 
@@ -40,7 +37,7 @@ OPTS=(
   "--accept-disclaimer"
   "--resolver-endpoint http://xud:8887/resolveraiden"
   "--eth-rpc-endpoint geth:8545"
-  "--password-file $XUD_DIR/passphrase.txt"
+  "--password-file $RAIDEN_DIR/passphrase.txt"
   "--datadir $RAIDEN_DIR"
   "--api-address 0.0.0.0:5001"
   "--matrix-server https://raidentransport.exchangeunion.com"

--- a/images/xud/entrypoint.sh
+++ b/images/xud/entrypoint.sh
@@ -2,10 +2,6 @@
 
 set -m
 
-if [[ ! -e ~/.xud/passphrase.txt ]]; then
-  touch ~/.xud/passphrase.txt
-fi
-
 wait_file() {
   local file="$1"; shift
   local wait_seconds="${1:-10}"; shift # after 10 seconds we give up

--- a/images/xud/xud.conf
+++ b/images/xud/xud.conf
@@ -69,7 +69,7 @@ listen = true
 port = <p2p_port>
 
 [raiden]
-keystorepath = "/root/.xud"
+keystorepath = "/root/.raiden"
 disable = false
 host = "raiden"
 port = 5001

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       - NETWORK=mainnet
     volumes:
       - ./data/raiden:/root/.raiden
-      - ./data/xud:/root/.xud
     logging: *default-logging
 
   xud:
@@ -102,6 +101,7 @@ services:
       - ./data/xud:/root/.xud
       - ./data/lndbtc:/root/.lndbtc
       - ./data/lndltc:/root/.lndltc
+      - ./data/raiden:/root/.raiden
     ports:
       - 8885:8885
     logging: *default-logging

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -92,7 +92,6 @@ services:
       - NETWORK=testnet
     volumes:
       - ./data/raiden:/root/.raiden
-      - ./data/xud:/root/.xud
     logging: *default-logging
 
   xud:
@@ -104,6 +103,7 @@ services:
       - ./data/xud:/root/.xud
       - ./data/lndbtc:/root/.lndbtc
       - ./data/lndltc:/root/.lndltc
+      - ./data/raiden:/root/.raiden
     ports:
       - 18885:18885
     logging: *default-logging


### PR DESCRIPTION
This commit moves the keystore file generated by xud's seedutil to
raiden's data directory `$network/data/raiden/keystore`.

Steps to test:
`bash xud.sh -b raiden-keystore-improvements`