### PR TITLE
fix: create raiden keystore output

### DIFF
--- a/images/xud/proxychains4.conf
+++ b/images/xud/proxychains4.conf
@@ -46,7 +46,7 @@ strict_chain
 #chain_len = 2
 
 # Quiet mode (no output from library)
-#quiet_mode
+quiet_mode
 
 # Proxy DNS requests - no leak for DNS data
 proxy_dns


### PR DESCRIPTION
This commit fixes an issue where `xucli create` didn't output: `The keystore for raiden was initialized.` because `xud` caught a stderr warning from `proxychains`.

It couldn't proxy requests made by `seedutil` child process.