### PR TITLE
fix: xucli unlock

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -33,7 +33,24 @@ alias up="docker-compose up"
 alias down="docker-compose down -t $GRACEFUL_SHUTDOWN_TIMEOUT"
 
 function xucli() {
-    docker-compose exec xud xucli $@ | sed -n '1!p'
+    LINE=""
+    #shellcheck disable=SC2068
+    docker-compose exec xud xucli $@ | while read -n 1; do
+        if [[ $REPLY == $'\n' ]]; then
+            if [[ ! $LINE =~ "<hide>" ]]; then
+                echo "$LINE"
+            fi
+            LINE=""
+        else
+            LINE="$LINE$REPLY"
+            if [[ $LINE =~ 'password: ' ]]; then
+                echo -n "$LINE"
+                LINE=""
+            elif [[ $LINE =~ getenv ]]; then
+                LINE="<hide>"
+            fi
+        fi
+  done
 }
 
 alias help="xucli help"

--- a/init.sh
+++ b/init.sh
@@ -50,7 +50,7 @@ function xucli() {
                 LINE="<hide>"
             fi
         fi
-  done
+    done
 }
 
 alias help="xucli help"

--- a/init.sh
+++ b/init.sh
@@ -36,9 +36,9 @@ function xucli() {
     LINE=""
     #shellcheck disable=SC2068
     docker-compose exec xud xucli $@ | while read -n 1; do
-        if [[ $REPLY == $'\n' ]]; then
+        if [[ $REPLY == $'\n' || $REPLY == $'\r' ]]; then
             if [[ ! $LINE =~ "<hide>" ]]; then
-                echo "$LINE"
+                echo -e "$LINE\r"
             fi
             LINE=""
         else


### PR DESCRIPTION
Resolves #180

The original `sed -n '1!p'` way to hide first warning line is not working with interactive command like unlock/create because sed print each line when `\n` is read. So inline prompt won't display until the user type Enter.

This PR replace sed with `while read...` to handle output of xucli character by character to solve the AFTER prompt problem.