### PR TITLE
fix: do not rewrite config for lnds

### DIFF
--- a/images/lnd/entrypoint.sh
+++ b/images/lnd/entrypoint.sh
@@ -9,7 +9,7 @@ cd "$SCRIPT_PATH" || exit 1
 LND_DIR="/root/.lnd"
 mkdir -p $LND_DIR
 
-if [[ $LND_REWRITE_CONFIG || ! -e $LND_DIR/lnd.conf ]]; then
+if [[ ! -e $LND_DIR/lnd.conf ]]; then
   if [ "$CHAIN" = "bitcoin" ]; then
     echo "[DEBUG] Using configuration for bitcoin"
     cp /root/lnd-btc.conf $LND_DIR/lnd.conf

--- a/images/lnd/entrypoint.sh
+++ b/images/lnd/entrypoint.sh
@@ -9,12 +9,14 @@ cd "$SCRIPT_PATH" || exit 1
 LND_DIR="/root/.lnd"
 mkdir -p $LND_DIR
 
-if [ "$CHAIN" = "bitcoin" ]; then
-  echo "[DEBUG] Using configuration for bitcoin"
-  cp /root/lnd-btc.conf $LND_DIR/lnd.conf
-else
-  echo "[DEBUG] Using configuration for litecoin"
-  cp /root/lnd-ltc.conf $LND_DIR/lnd.conf
+if [[ $LND_REWRITE_CONFIG || ! -e $LND_DIR/lnd.conf ]]; then
+  if [ "$CHAIN" = "bitcoin" ]; then
+    echo "[DEBUG] Using configuration for bitcoin"
+    cp /root/lnd-btc.conf $LND_DIR/lnd.conf
+  else
+    echo "[DEBUG] Using configuration for litecoin"
+    cp /root/lnd-ltc.conf $LND_DIR/lnd.conf
+  fi
 fi
 
 LND_HOSTNAME="$HOME/.lnd/tor/hostname"


### PR DESCRIPTION
This commit adds a check to avoid rewriting lnd's configuration file if it already exists.