### PR TITLE
chore: update GETH to v1.9.6

### DIFF
--- a/images/versions.ini
+++ b/images/versions.ini
@@ -10,7 +10,7 @@ node = lts-alpine ; node 10, alpine 3.9
 bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = lightningnetwork/lnd:v0.7.1-beta
-geth = v1.9.1
+geth = v1.9.6
 raiden = ExchangeUnion/raiden:develop
 xud = ExchangeUnion/xud:master
 
@@ -18,6 +18,6 @@ xud = ExchangeUnion/xud:master
 bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = 0.7.1-beta
-geth = 1.9.1
+geth = 1.9.6
 raiden = latest
 xud = latest

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     logging: *default-logging
 
   geth:
-    image: exchangeunion/geth:1.9.1
+    image: exchangeunion/geth:1.9.6
     hostname: geth
     environment:
       - NETWORK=mainnet

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     logging: *default-logging
 
   geth:
-    image: exchangeunion/geth:1.9.1
+    image: exchangeunion/geth:1.9.6
     hostname: geth
     environment:
       - NETWORK=testnet


### PR DESCRIPTION
This PR updates GETH to the latest version: [Elasa (v1.9.6)](https://github.com/ethereum/go-ethereum/releases/tag/v1.9.6)

*Doesn't have to be merged before tagging the first release*