### PR TITLE
feat: customize bitcoind, litecoind and geth data directories

### DIFF
--- a/images/geth/entrypoint.sh
+++ b/images/geth/entrypoint.sh
@@ -15,6 +15,7 @@ OPTS=(
   "--rpcvhosts=*"
   "--cache=1024"
   "--nousb"
+  "--datadir.ancient=$ETHEREUM_DIR/chaindata"
 )
 
 if [[ $NETWORK == "testnet" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,7 @@ NETWORK=
 BITCOIND_DIR=
 LITECOIND_DIR=
 GETH_DIR=
+GETH_CHAINDATA_DIR=
 LOGFILE=
 
 function parse_arguments() {
@@ -94,6 +95,15 @@ function parse_arguments() {
                 exit 1
             fi
             GETH_DIR=$1
+            ;;
+        "--geth-chaindata-dir")
+            OPTION=$1
+            shift
+            if [[ $# -eq 0 || $1 =~ ^- ]]; then
+                echo >&2 "❌ Missing option value: $OPTION"
+                exit 1
+            fi
+            GETH_CHAINDATA_DIR=$1
             ;;
         "--logfile")
             OPTION=$1
@@ -582,6 +592,9 @@ if [[ -n $LITECOIND_DIR ]]; then
 fi
 if [[ -n $GETH_DIR ]]; then
     VARS+=("GETH_DIR=$GETH_DIR")
+fi
+if [[ -n $GETH_CHAINDATA_DIR ]]; then
+    VARS+=("GETH_CHAINDATA_DIR=$GETH_CHAINDATA_DIR")
 fi
 if [[ ${#VARS[@]} -gt 0 ]]; then
     DOCKER_COMPOSE="env ${VARS[*]} docker-compose -p $NETWORK"

--- a/setup.sh
+++ b/setup.sh
@@ -20,6 +20,9 @@ BRANCH=master
 PROJECT_DIR=
 HOME_DIR=~/.xud-docker
 NETWORK=
+BITCOIND_DIR=
+LITECOIND_DIR=
+GETH_DIR=
 LOGFILE=
 
 function parse_arguments() {
@@ -64,6 +67,33 @@ function parse_arguments() {
                 exit 1
             fi
             HOME_DIR=$1
+            ;;
+        "--bitcoind-dir")
+            OPTION=$1
+            shift
+            if [[ $# -eq 0 || $1 =~ ^- ]]; then
+                echo >&2 "❌ Missing option value: $OPTION"
+                exit 1
+            fi
+            BITCOIND_DIR=$1
+            ;;
+        "--litecoind-dir")
+            OPTION=$1
+            shift
+            if [[ $# -eq 0 || $1 =~ ^- ]]; then
+                echo >&2 "❌ Missing option value: $OPTION"
+                exit 1
+            fi
+            LITECOIND_DIR=$1
+            ;;
+        "--geth-dir")
+            OPTION=$1
+            shift
+            if [[ $# -eq 0 || $1 =~ ^- ]]; then
+                echo >&2 "❌ Missing option value: $OPTION"
+                exit 1
+            fi
+            GETH_DIR=$1
             ;;
         "--logfile")
             OPTION=$1
@@ -486,10 +516,8 @@ function is_all_containers_up() {
 }
 
 function launch_xudctl() {
-    if ! is_all_containers_up; then
-        echo "🚀 Launching $NETWORK environment"
-        $DOCKER_COMPOSE up -d
-    fi
+    echo "🚀 Launching $NETWORK environment"
+    $DOCKER_COMPOSE up -d
 
     if [[ $NETWORK == 'testnet' || $NETWORK == 'mainnet' ]]; then
         check_wallets
@@ -545,7 +573,21 @@ case $REPLY in
 esac
 shopt -u nocasematch
 
-DOCKER_COMPOSE="docker-compose -p $NETWORK"
+VARS=()
+if [[ -n $BITCOIND_DIR ]]; then
+    VARS+=("BITCOIND_DIR=$BITCOIND_DIR")
+fi
+if [[ -n $LITECOIND_DIR ]]; then
+    VARS+=("LITECOIND_DIR=$LITECOIND_DIR")
+fi
+if [[ -n $GETH_DIR ]]; then
+    VARS+=("GETH_DIR=$GETH_DIR")
+fi
+if [[ ${#VARS[@]} -gt 0 ]]; then
+    DOCKER_COMPOSE="env ${VARS[*]} docker-compose -p $NETWORK"
+else
+    DOCKER_COMPOSE="docker-compose -p $NETWORK"
+fi
 
 check_directory "$HOME_DIR"
 HOME_DIR=$(realpath "$HOME_DIR")

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       -rpcallowip=::/0
       -rpcbind=0.0.0.0
     volumes:
-      - ./data/bitcoind:/root/.bitcoin
+      - ${BITCOIND_DIR:-./data/bitcoind}:/root/.bitcoin
     logging: *default-logging
 
   litecoind:
@@ -47,7 +47,7 @@ services:
       -rpcallowip=::/0
       -rpcbind=0.0.0.0
     volumes:
-      - ./data/litecoind:/root/.litecoin
+      - ${LITECOIND_DIR:-./data/litecoind}:/root/.litecoin
     logging: *default-logging
 
   lndbtc:
@@ -84,7 +84,7 @@ services:
     environment:
       - NETWORK=mainnet
     volumes:
-      - ./data/geth:/root/.ethereum
+      - ${GETH_DIR:-./data/geth}:/root/.ethereum
     logging: *default-logging
 
   raiden:

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - NETWORK=mainnet
     volumes:
       - ${GETH_DIR:-./data/geth}:/root/.ethereum
+      - ${GETH_CHAINDATA_DIR:-./data/geth/chaindata}:/root/.ethereum/chaindata
     logging: *default-logging
 
   raiden:

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       -rpcallowip=::/0
       -rpcbind=0.0.0.0
     volumes:
-      - ./data/bitcoind:/root/.bitcoin
+      - ${BITCOIND_DIR:-./data/bitcoind}:/root/.bitcoin
     logging: *default-logging
 
   litecoind:
@@ -49,7 +49,7 @@ services:
       -rpcallowip=::/0
       -rpcbind=0.0.0.0
     volumes:
-      - ./data/litecoind:/root/.litecoin
+      - ${LITECOIND_DIR:-./data/litecoind}:/root/.litecoin
     logging: *default-logging
 
   lndbtc:
@@ -86,7 +86,7 @@ services:
     environment:
       - NETWORK=testnet
     volumes:
-      - ./data/geth:/root/.ethereum
+      - ${GETH_DIR:-./data/geth}:/root/.ethereum
     logging: *default-logging
 
   raiden:

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - NETWORK=testnet
     volumes:
       - ${GETH_DIR:-./data/geth}:/root/.ethereum
+      - ${GETH_CHAINDATA_DIR:-./data/geth/chaindata}:/root/.ethereum/chaindata
     logging: *default-logging
 
   raiden:

--- a/xud.sh
+++ b/xud.sh
@@ -2,12 +2,36 @@
 
 set -euo pipefail
 
-branch=master
+BRANCH=master
 
-while getopts b: opt 2>/dev/null; do
-    case "$opt" in
-        b) branch=$OPTARG;;
-    esac
-done
+function parse_arguments() {
+    local OPTION VALUE
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        "-b" | "--branch")
+            if [[ $1 =~ = ]]; then
+                VALUE=$(echo "$1" | cut -d'=' -f2)
+            else
+                OPTION=$1
+                shift
+                if [[ $# -eq 0 || $1 =~ ^- ]]; then
+                    echo >&2 "❌ Missing option value: $OPTION"
+                    exit 1
+                fi
+                if ! curl -sf -o /dev/null https://api.github.com/repos/ExchangeUnion/xud-docker/git/refs/heads/$1; then
+                    echo >&2 "❌ Branch \"$1\" does not exist"
+                    exit 1
+                fi
+                VALUE=$1
+            fi
+            BRANCH=$VALUE
+            ;;
+        *)
+            shift
+        esac
+    done
+}
 
-bash <(curl -sf https://raw.githubusercontent.com/ExchangeUnion/xud-docker/$branch/setup.sh) $@
+parse_arguments "$@"
+
+bash <(curl -sf "https://raw.githubusercontent.com/ExchangeUnion/xud-docker/$BRANCH/setup.sh") "$@"


### PR DESCRIPTION
This closes #202.

This commit adds 3 new command line options `--bitcoind-dir`, `--litecoind-dir` and `--geth-dir` to customize corresponding services' data directories. The implementation uses environment variables before `docker-compose` command to inject variables into docker-compose file.

**ATTENTION!** This commit updates `xud.sh` becuase `getopts` takes `--bitcoind-dir` as `-b<branch>`

Updates:

* `--geth-chaindata-dir`