### PR TITLE
chore: update GETH to v1.9.7

### DIFF
--- a/images/versions.ini
+++ b/images/versions.ini
@@ -10,7 +10,7 @@ node = lts-alpine ; node 10, alpine 3.9
 bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = lightningnetwork/lnd:v0.7.1-beta
-geth = v1.9.6
+geth = v1.9.7
 raiden = ExchangeUnion/raiden:develop
 xud = ExchangeUnion/xud:master
 
@@ -18,6 +18,6 @@ xud = ExchangeUnion/xud:master
 bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = 0.7.1-beta
-geth = 1.9.6
+geth = 1.9.7
 raiden = latest
 xud = latest

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     logging: *default-logging
 
   geth:
-    image: exchangeunion/geth:1.9.6
+    image: exchangeunion/geth:1.9.7
     hostname: geth
     environment:
       - NETWORK=mainnet

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     logging: *default-logging
 
   geth:
-    image: exchangeunion/geth:1.9.6
+    image: exchangeunion/geth:1.9.7
     hostname: geth
     environment:
       - NETWORK=testnet


### PR DESCRIPTION
Closes #228 

This PR updates GETH to version `v1.9.7`. The only change relevant to us is:

> This release is a bit more special, however, as it finally initializes the Ethereum mainnet Istanbul fork block 9069000, targeted to arrive around the 4th of December! 
