### PR TITLE
chore: update GETH to v1.9.8

### DIFF
--- a/images/versions.ini
+++ b/images/versions.ini
@@ -10,7 +10,7 @@ node = lts-alpine ; node 10, alpine 3.9
 bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = lightningnetwork/lnd:v0.7.1-beta
-geth = v1.9.7
+geth = v1.9.8
 raiden = ExchangeUnion/raiden:develop
 xud = ExchangeUnion/xud:master
 
@@ -18,6 +18,6 @@ xud = ExchangeUnion/xud:master
 bitcoind = 0.18.1
 litecoind = 0.17.1
 lnd = 0.7.1-beta
-geth = 1.9.7
+geth = 1.9.8
 raiden = latest
 xud = latest

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     logging: *default-logging
 
   geth:
-    image: exchangeunion/geth:1.9.7
+    image: exchangeunion/geth:1.9.8
     hostname: geth
     environment:
       - NETWORK=mainnet

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     logging: *default-logging
 
   geth:
-    image: exchangeunion/geth:1.9.7
+    image: exchangeunion/geth:1.9.8
     hostname: geth
     environment:
       - NETWORK=testnet


### PR DESCRIPTION
This PR updates GETH to version `v1.9.8`. The only change in this version relevant to our Docker setup is: `replacing the trie cacher, slashing memory consumption on mainnet - using default configs - by 1GB`.

[Full release notes](https://github.com/ethereum/go-ethereum/releases/tag/v1.9.8)