### PR TITLE
chore: update Bitcoin Core and LND

### DIFF
--- a/images/lnd/lnd-btc.conf
+++ b/images/lnd/lnd-btc.conf
@@ -1,6 +1,7 @@
 debuglevel=debug
 rpclisten=0.0.0.0:10009
 restlisten=0.0.0.0:8080
+max-cltv-expiry=5000
 
 [Bitcoin]
 bitcoin.active=1

--- a/images/lnd/lnd-ltc.conf
+++ b/images/lnd/lnd-ltc.conf
@@ -1,6 +1,7 @@
 debuglevel=debug
 rpclisten=0.0.0.0:10009
 restlisten=0.0.0.0:8080
+max-cltv-expiry=20000
 
 [Litecoin]
 litecoin.active=1

--- a/images/versions.ini
+++ b/images/versions.ini
@@ -7,17 +7,17 @@ python = 3.7-alpine3.10
 node = lts-alpine ; node 10, alpine 3.9
 
 [application]
-bitcoind = 0.18.1
+bitcoind = 0.19.0.1
 litecoind = 0.17.1
-lnd = lightningnetwork/lnd:v0.7.1-beta
+lnd = lightningnetwork/lnd:v0.8.2-beta
 geth = v1.9.9
 raiden = ExchangeUnion/raiden:develop
 xud = ExchangeUnion/xud:master
 
 [tag]
-bitcoind = 0.18.1
+bitcoind = 0.19.0.1
 litecoind = 0.17.1
-lnd = 0.7.1-beta
+lnd = 0.8.2-beta
 geth = 1.9.9
 raiden = latest
 xud = latest

--- a/xud-mainnet/docker-compose.yml
+++ b/xud-mainnet/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   bitcoind:
-    image: exchangeunion/bitcoind:0.18.1
+    image: exchangeunion/bitcoind:0.19.0.1
     hostname: bitcoind
     environment:
       - NETWORK=mainnet
@@ -39,7 +39,7 @@ services:
     logging: *default-logging
 
   lndbtc:
-    image: exchangeunion/lnd:0.7.1-beta
+    image: exchangeunion/lnd:0.8.2-beta
     hostname: lndbtc
     environment:
       - NETWORK=mainnet
@@ -53,7 +53,7 @@ services:
     logging: *default-logging
 
   lndltc:
-    image: exchangeunion/lnd:0.7.1-beta
+    image: exchangeunion/lnd:0.8.2-beta
     hostname: lndltc
     environment:
       - NETWORK=mainnet

--- a/xud-testnet/docker-compose.yml
+++ b/xud-testnet/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   bitcoind:
-    image: exchangeunion/bitcoind:0.18.1
+    image: exchangeunion/bitcoind:0.19.0.1
     hostname: bitcoind
     environment:
       - NETWORK=testnet
@@ -40,7 +40,7 @@ services:
     logging: *default-logging
 
   lndbtc:
-    image: exchangeunion/lnd:0.7.1-beta
+    image: exchangeunion/lnd:0.8.2-beta
     hostname: lndbtc
     environment:
       - NETWORK=testnet
@@ -54,7 +54,7 @@ services:
     logging: *default-logging
 
   lndltc:
-    image: exchangeunion/lnd:0.7.1-beta
+    image: exchangeunion/lnd:0.8.2-beta
     hostname: lndltc
     environment:
       - NETWORK=testnet


### PR DESCRIPTION
Could someone with a synced testnet instance please make sure that the new LND version didn't break the swaps?