### PR TITLE
feat: build all images on aarch64 architecture

### DIFF
--- a/images/bitcoind/Dockerfile.aarch64
+++ b/images/bitcoind/Dockerfile.aarch64
@@ -1,0 +1,42 @@
+ARG ALPINE_VERSION
+
+FROM alpine:$ALPINE_VERSION as builder
+ARG VERSION
+
+RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boost-dev libressl-dev libevent-dev zeromq-dev
+
+WORKDIR /tmp
+RUN wget https://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
+RUN tar -xzf db-4.8.30.tar.gz
+
+WORKDIR /tmp/db-4.8.30/build_unix
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ../dbinc/atomic.h
+RUN ../dist/configure --prefix=/usr/local --enable-cxx --with-pic --disable-shared --disable-replication --build=arm-alpine-linux --host=arm-unknown-linux --target=arm-unknown-linux
+RUN make -j$(nproc)
+RUN make install
+
+WORKDIR /tmp
+RUN wget https://bitcoin.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION.tar.gz
+RUN tar -xzf bitcoin-$VERSION.tar.gz
+WORKDIR /tmp/bitcoin-$VERSION
+
+RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
+RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
+RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
+
+RUN ./autogen.sh
+RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs
+
+RUN make -j$(nproc)
+RUN make install
+
+RUN strip /usr/local/bin/bitcoind /usr/local/bin/bitcoin-cli
+
+
+FROM alpine:$ALPINE_VERSION
+ARG VERSION
+RUN apk --no-cache add boost-system boost-filesystem boost-chrono boost-thread libevent libressl zeromq bash
+COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin
+COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin
+ENTRYPOINT ["bitcoind"]
+EXPOSE 8332 18332 28332 28333

--- a/images/bitcoind/Dockerfile.aarch64
+++ b/images/bitcoind/Dockerfile.aarch64
@@ -2,34 +2,18 @@ ARG ALPINE_VERSION
 
 FROM alpine:$ALPINE_VERSION as builder
 ARG VERSION
-
 RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boost-dev libressl-dev libevent-dev zeromq-dev
-
-WORKDIR /tmp
-RUN wget https://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
-RUN tar -xzf db-4.8.30.tar.gz
-
-WORKDIR /tmp/db-4.8.30/build_unix
-RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ../dbinc/atomic.h
-RUN ../dist/configure --prefix=/usr/local --enable-cxx --with-pic --disable-shared --disable-replication --build=arm-alpine-linux --host=arm-unknown-linux --target=arm-unknown-linux
-RUN make -j$(nproc)
-RUN make install
-
 WORKDIR /tmp
 RUN wget https://bitcoin.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION.tar.gz
 RUN tar -xzf bitcoin-$VERSION.tar.gz
 WORKDIR /tmp/bitcoin-$VERSION
-
 RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
 RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
 RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
-
 RUN ./autogen.sh
-RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs
-
+RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs --disable-wallet
 RUN make -j$(nproc)
 RUN make install
-
 RUN strip /usr/local/bin/bitcoind /usr/local/bin/bitcoin-cli
 
 

--- a/images/geth/Dockerfile.aarch64
+++ b/images/geth/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+ARG GOLANG_VERSION
+ARG ALPINE_VERSION
+
+FROM golang:$GOLANG_VERSION as builder
+ARG VERSION
+RUN apk add --no-cache make gcc musl-dev linux-headers git
+RUN apk add --no-cache alpine-sdk
+RUN git clone -b $VERSION https://github.com/ethereum/go-ethereum.git /go-ethereum
+WORKDIR /go-ethereum
+RUN make geth
+
+FROM alpine:$ALPINE_VERSION
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+COPY entrypoint.sh ropsten-peers.txt mainnet-peers.txt /
+EXPOSE 8545 8546 8547 30303 30303/udp
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/images/geth/Dockerfile.aarch64
+++ b/images/geth/Dockerfile.aarch64
@@ -10,7 +10,7 @@ WORKDIR /go-ethereum
 RUN make geth
 
 FROM alpine:$ALPINE_VERSION
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates bash
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 COPY entrypoint.sh ropsten-peers.txt mainnet-peers.txt /
 EXPOSE 8545 8546 8547 30303 30303/udp

--- a/images/geth/Dockerfile.aarch64
+++ b/images/geth/Dockerfile.aarch64
@@ -1,7 +1,7 @@
 ARG GOLANG_VERSION
 ARG ALPINE_VERSION
 
-FROM golang:$GOLANG_VERSION as builder
+FROM golang:1.13-alpine3.10 as builder
 ARG VERSION
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 RUN apk add --no-cache alpine-sdk

--- a/images/geth/entrypoint.sh
+++ b/images/geth/entrypoint.sh
@@ -13,7 +13,7 @@ OPTS=(
   "--rpcaddr 0.0.0.0"
   "--rpcapi eth,net,web3,txpool,personal,admin"
   "--rpcvhosts=*"
-  "--cache=1024"
+  "--cache=256"
   "--nousb"
   "--datadir.ancient=$ETHEREUM_DIR/chaindata"
 )

--- a/images/litecoind/Dockerfile.aarch64
+++ b/images/litecoind/Dockerfile.aarch64
@@ -2,35 +2,19 @@ ARG ALPINE_VERSION
 
 FROM alpine:$ALPINE_VERSION as builder
 ARG VERSION
-
 RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boost-dev libressl-dev libevent-dev zeromq-dev
-
-WORKDIR /tmp
-RUN wget https://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
-RUN tar -xzf db-4.8.30.tar.gz
-
-WORKDIR /tmp/db-4.8.30/build_unix
-RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ../dbinc/atomic.h
-RUN ../dist/configure --prefix=/usr/local --enable-cxx --with-pic --disable-shared --disable-replication --build=arm-alpine-linux --host=arm-unknown-linux --target=arm-unknown-linux
-RUN make -j$(nproc)
-RUN make install
-
 WORKDIR /tmp
 RUN wget https://github.com/litecoin-project/litecoin/archive/v$VERSION.tar.gz
-
 RUN tar -xzf v*.tar.gz
 WORKDIR /tmp/litecoin-$VERSION
 RUN ./autogen.sh
-
 # https://github.com/litecoin-project/litecoin/issues/407#issuecomment-458422310
 # https://wiki.musl-libc.org/functional-differences-from-glibc.html
 RUN sed -i '/char\ scratchpad\[SCRYPT_SCRATCHPAD_SIZE\];/a\memset(scratchpad, 0, sizeof(scratchpad));' src/crypto/scrypt.cpp
 RUN sed -i 's/char\ scratchpad\[SCRYPT_SCRATCHPAD_SIZE\];/static &/g' src/crypto/scrypt.cpp
-
-RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs
+RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs --disable-wallet
 RUN make -j$(nproc)
 RUN make install
-
 RUN strip /usr/local/bin/litecoind /usr/local/bin/litecoin-cli
 
 

--- a/images/litecoind/Dockerfile.aarch64
+++ b/images/litecoind/Dockerfile.aarch64
@@ -1,0 +1,44 @@
+ARG ALPINE_VERSION
+
+FROM alpine:$ALPINE_VERSION as builder
+ARG VERSION
+
+RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boost-dev libressl-dev libevent-dev zeromq-dev
+
+WORKDIR /tmp
+RUN wget https://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
+RUN tar -xzf db-4.8.30.tar.gz
+
+WORKDIR /tmp/db-4.8.30/build_unix
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ../dbinc/atomic.h
+RUN ../dist/configure --prefix=/usr/local --enable-cxx --with-pic --disable-shared --disable-replication --build=arm-alpine-linux --host=arm-unknown-linux --target=arm-unknown-linux
+RUN make -j$(nproc)
+RUN make install
+
+WORKDIR /tmp
+RUN wget https://github.com/litecoin-project/litecoin/archive/v$VERSION.tar.gz
+
+RUN tar -xzf v*.tar.gz
+WORKDIR /tmp/litecoin-$VERSION
+RUN ./autogen.sh
+
+# https://github.com/litecoin-project/litecoin/issues/407#issuecomment-458422310
+# https://wiki.musl-libc.org/functional-differences-from-glibc.html
+RUN sed -i '/char\ scratchpad\[SCRYPT_SCRATCHPAD_SIZE\];/a\memset(scratchpad, 0, sizeof(scratchpad));' src/crypto/scrypt.cpp
+RUN sed -i 's/char\ scratchpad\[SCRYPT_SCRATCHPAD_SIZE\];/static &/g' src/crypto/scrypt.cpp
+
+RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs
+RUN make -j$(nproc)
+RUN make install
+
+RUN strip /usr/local/bin/litecoind /usr/local/bin/litecoin-cli
+
+
+FROM alpine:$ALPINE_VERSION
+ARG VERSION
+RUN apk --no-cache add boost-system boost-filesystem boost-chrono boost-thread libevent libressl zeromq bash
+COPY --from=builder /usr/local/bin/litecoind /usr/local/bin/
+COPY --from=builder /usr/local/bin/litecoin-cli /usr/local/bin/
+ADD entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+EXPOSE 9332 19332 29332 29333

--- a/images/lnd-simnet/Dockerfile.aarch64
+++ b/images/lnd-simnet/Dockerfile.aarch64
@@ -8,6 +8,6 @@ COPY lnd-btc.conf lnd-ltc.conf /root/
 COPY supervisord.conf /etc/supervisor/conf.d/
 COPY torrc /etc/tor/
 VOLUME ["/root/.lnd"]
-RUN mkdir /root/.lnd/tor
+RUN mkdir -p /root/.lnd/tor
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 EXPOSE 10009

--- a/images/lnd-simnet/Dockerfile.aarch64
+++ b/images/lnd-simnet/Dockerfile.aarch64
@@ -1,0 +1,13 @@
+ARG ALPINE_VERSION
+
+FROM alpine:$ALPINE_VERSION
+RUN apk add --no-cache bash expect supervisor tor
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/go/bin/lnd /root/xud-simnet/go/bin/lncli /usr/local/bin/
+COPY entrypoint.sh wait-file.sh peers.sh start_tor.sh /
+COPY lnd-btc.conf lnd-ltc.conf /root/
+COPY supervisord.conf /etc/supervisor/conf.d/
+COPY torrc /etc/tor/
+VOLUME ["/root/.lnd"]
+RUN mkdir /root/.lnd/tor
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+EXPOSE 10009

--- a/images/lnd/Dockerfile.aarch64
+++ b/images/lnd/Dockerfile.aarch64
@@ -1,0 +1,25 @@
+ARG GOLANG_VERSION
+ARG ALPINE_VERSION
+
+FROM golang:$GOLANG_VERSION as builder
+ARG REPO
+ARG BRANCH
+RUN apk add --no-cache bash git make
+RUN apk add --no-cache gcc
+RUN apk add --no-cache alpine-sdk
+RUN git clone -b ${BRANCH} https://github.com/${REPO} $GOPATH/src/github.com/lightningnetwork/lnd
+WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
+RUN make tags="invoicesrpc" install
+
+# Final stage
+FROM alpine:$ALPINE_VERSION
+RUN apk add --no-cache bash expect supervisor tor
+COPY --from=builder /go/bin/lnd /go/bin/lncli /usr/local/bin/
+COPY entrypoint.sh wait-file.sh start_tor.sh /
+COPY lnd-btc.conf lnd-ltc.conf /root/
+COPY supervisord.conf /etc/supervisor/conf.d/
+COPY torrc /etc/tor/
+VOLUME [ "/root/.lnd" ]
+RUN mkdir -p /root/.lnd/tor
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+EXPOSE 10009 9735 19735 10735 20735

--- a/images/ltcd-simnet/Dockerfile.aarch64
+++ b/images/ltcd-simnet/Dockerfile.aarch64
@@ -1,0 +1,9 @@
+ARG ALPINE_VERSION
+
+FROM alpine:$ALPINE_VERSION
+RUN apk add --no-cache bash
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/go/bin/ltcd /root/xud-simnet/go/bin/ltcctl /usr/local/bin/
+COPY entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]
+VOLUME [ "/root/.ltcd" ]
+EXPOSE 18556

--- a/images/raiden-simnet/Dockerfile.aarch64
+++ b/images/raiden-simnet/Dockerfile.aarch64
@@ -1,0 +1,10 @@
+ARG PYTHON_VERSION
+
+FROM python:$PYTHON_VERSION
+RUN apk add --no-cache bash curl supervisor
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/raiden-wd/venv/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY entrypoint.sh onboarder.py /opt/
+COPY supervisord.conf /etc/supervisor/conf.d/
+WORKDIR /opt
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+EXPOSE 5001

--- a/images/utils/launcher/node/base.py
+++ b/images/utils/launcher/node/base.py
@@ -70,7 +70,7 @@ class Node:
 
     @property
     def network_dir(self):
-        return f"{self._config.home_dir}/{self.network}"
+        return self._config.network_dir
 
     @property
     def image(self):

--- a/images/xud-simnet/Dockerfile.aarch64
+++ b/images/xud-simnet/Dockerfile.aarch64
@@ -1,0 +1,20 @@
+ARG NODE_VERSION
+
+FROM node:$NODE_VERSION
+RUN apk add --no-cache bash proxychains-ng supervisor tor
+RUN mkdir /root/.xud
+VOLUME [ "/root/.xud" ]
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/xud/dist /app/dist
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/xud/bin  /app/bin
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/xud/package.json /app/
+COPY --from=exchangeunion/xud-simnet-install /root/xud-simnet/xud/node_modules /app/node_modules
+COPY xud.conf /tmp/
+COPY entrypoint.sh /app
+RUN ln -s /app/bin/xucli /bin/xucli
+COPY proxychains4.conf /etc/proxychains/proxychains.conf
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY torrc /etc/tor/torrc
+RUN mkdir /root/.xud/tor
+WORKDIR /app
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+EXPOSE 28885 8887

--- a/images/xud/Dockerfile.aarch64
+++ b/images/xud/Dockerfile.aarch64
@@ -1,0 +1,43 @@
+ARG NODE_VERSION
+
+FROM node:$NODE_VERSION AS builder
+ARG REPO
+ARG BRANCH
+# Use pure JS implemented secp256k1 bindings
+RUN apk add --no-cache git rsync bash musl-dev go
+RUN apk add --no-cache alpine-sdk
+RUN apk add --no-cache python3
+RUN apk add --no-cache python
+# This is a "hack" to automatically invalidate the cache in case there are new commits
+#ADD https://api.github.com/repos/${REPO}/commits/${BRANCH} /dev/null
+RUN git clone -b ${BRANCH} https://github.com/${REPO}
+WORKDIR /xud
+RUN git show HEAD > git_head.txt
+RUN sed -Ei 's/argv.password/password1/g' lib/cli/commands/create.ts
+RUN sed -Ei 's/"grpc-tools": "1.8.0",//g' package.json
+RUN npm install
+RUN npm run compile
+RUN npm run compile:seedutil
+
+# Final stage
+FROM node:$NODE_VERSION
+RUN apk add --no-cache bash proxychains-ng supervisor tor
+RUN mkdir /root/.xud
+VOLUME [ "/root/.xud" ]
+COPY --from=builder /xud/dist /app/dist
+COPY --from=builder /xud/bin  /app/bin
+COPY --from=builder /xud/package.json /app/
+COPY --from=builder /xud/node_modules /app/node_modules
+COPY --from=builder /xud/git_head.txt /app/
+COPY --from=builder /xud/seedutil/seedutil /app/seedutil/seedutil
+COPY xud.conf /tmp/
+COPY entrypoint.sh /app
+COPY start_tor.sh /
+RUN ln -s /app/bin/xucli /bin/xucli
+COPY proxychains4.conf /etc/proxychains/proxychains.conf
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY torrc /etc/tor/torrc
+RUN mkdir /root/.xud/tor
+WORKDIR /app
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+EXPOSE 8885 18885 8887

--- a/supports/Dockerfile.aarch64
+++ b/supports/Dockerfile.aarch64
@@ -1,0 +1,6 @@
+FROM node:12-alpine3.10
+RUN apk add --no-cache git bash make python3 python3-dev python go rsync musl-dev libffi-dev patch
+RUN apk add --no-cache g++
+ADD xud-simnet /root/xud-simnet
+ADD install-raiden.sh install.sh /
+RUN /install.sh

--- a/supports/Dockerfile.aarch64
+++ b/supports/Dockerfile.aarch64
@@ -3,4 +3,6 @@ RUN apk add --no-cache git bash make python3 python3-dev python go rsync musl-de
 RUN apk add --no-cache g++
 ADD xud-simnet /root/xud-simnet
 ADD install-raiden.sh install.sh /
+# Use '"'"' to escape single quote inside single quote string
+RUN sed -Ei '/cd xud/a sed -Ei '"'"'s/"grpc-tools": "1.8.0",//g\'"'"' package.json' /root/xud-simnet/scripts/xud-simnet-install
 RUN /install.sh

--- a/supports/install.sh
+++ b/supports/install.sh
@@ -7,4 +7,5 @@ if bash -x scripts/xud-simnet-install; then
     /install-raiden.sh
 else
     echo "!!! Failed to execute xud-simnet-install !!!"
+    exit 1
 fi

--- a/supports/install.sh
+++ b/supports/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd /root/xud-simnet
+if bash -x scripts/xud-simnet-install; then
+    /install-raiden.sh
+else
+    echo "Failed to execute xud-simnet-install"
+    cat /tmp/*
+fi

--- a/supports/install.sh
+++ b/supports/install.sh
@@ -6,6 +6,5 @@ cd /root/xud-simnet
 if bash -x scripts/xud-simnet-install; then
     /install-raiden.sh
 else
-    echo "Failed to execute xud-simnet-install"
-    cat /tmp/*
+    echo "!!! Failed to execute xud-simnet-install !!!"
 fi

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -89,8 +89,11 @@ def build_xud_simnet(platform):
     exit_code = os.system(cmd)
 
     if exit_code != 0:
-        print("Failed to build xud-simnet image", file=sys.stderr)
         exit(1)
+
+    if platform == "linux/arm64":
+        os.system("docker tag xud-simnet exchangeunion/xud-simnet-install")
+        os.system("docker push exchangeunion/xud-simnet-install")
 
 
 def build(image, platform):

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -78,7 +78,7 @@ def get_dockerfile(platform):
 def build_xud_simnet(platform):
     dockerfile = get_dockerfile(platform)
     if platform:
-        cmd = "docker buildx build --platform {} . -t xud-simnet -f {} --progress plain".format(platform, dockerfile)
+        cmd = "docker buildx build --platform {} . -t xud-simnet -f {} --progress plain --load".format(platform, dockerfile)
     else:
         cmd = "docker build . -t xud-simnet"
 


### PR DESCRIPTION
This commit enhanced tools/build command with --platform option. You can use this option to build the image on specific architecture like "linux/arm64". And if there is another Dockerfile with some suffixes like aarch64, armhf, pppc64le, s390x, solaris and windows, tools/build will use a corresponding Dockerfile according to your --platform value.

How to test this PR?
- Clone this repository and checkout feat/arm branch
- Ensure that you have installed [buildx plugin](https://docs.docker.com/buildx/working-with-buildx/) for Docker
- Run `tools/build --platform linux/arm64`

Closes https://github.com/ExchangeUnion/xud-docker/issues/257