### PR TITLE
fix: <network>-dir not working in xud-docker.conf

### DIFF
--- a/images/utils/config_parser.py
+++ b/images/utils/config_parser.py
@@ -7,7 +7,7 @@ import os
 
 def _parse_xud_docker_conf():
     with open("/root/.xud-docker/xud-docker.conf") as f:
-        return toml.load(f.read())
+        return toml.loads(f.read())
 
 
 home_dir = os.environ["HOME_DIR"]
@@ -17,12 +17,11 @@ backup_dir = None
 
 try:
     parsed = _parse_xud_docker_conf()
-    value = parsed[f"{network}-dir"]
-    if value != network_dir:
-        network_dir = value
-    backup_dir = parsed["backup-dir"]
-except:
-    pass
+    network_dir = parsed.get(f"{network}-dir", network_dir)
+    backup_dir = parsed.get("backup-dir", backup_dir)
+except Exception as e:
+    print("Failed to parse xud-docker.conf:", e)
+    exit(1)
 
 parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
 parser.add_argument(f"--{network}-dir")
@@ -34,7 +33,6 @@ if hasattr(args, f"{network}_dir"):
 if hasattr(args, "backup_dir"):
     backup_dir = getattr(args, "backup_dir")
 
-result = f"NETWORK_DIR={network_dir}"
+print(f"NETWORK_DIR={network_dir}")
 if backup_dir:
-    result += f" && BACKUP_DIR={backup_dir}"
-print(result)
+    print(f"BACKUP_DIR={backup_dir}")

--- a/images/utils/config_parser.py
+++ b/images/utils/config_parser.py
@@ -19,7 +19,7 @@ try:
     parsed = _parse_xud_docker_conf()
     network_dir = parsed.get(f"{network}-dir", network_dir)
     backup_dir = parsed.get("backup-dir", backup_dir)
-except Exception as e:
+except toml.TomlDecodeError as e:
     print("Failed to parse xud-docker.conf:", e)
     exit(1)
 

--- a/images/utils/config_parser.py
+++ b/images/utils/config_parser.py
@@ -3,6 +3,7 @@
 import argparse
 import toml
 import os
+from shutil import copyfile
 
 
 def _parse_xud_docker_conf():
@@ -14,6 +15,8 @@ home_dir = os.environ["HOME_DIR"]
 network = os.environ["NETWORK"]
 network_dir = home_dir + "/" + network
 backup_dir = None
+
+copyfile("/usr/local/lib/python3.8/site-packages/launcher/config/xud-docker.conf", "/root/.xud-docker/sample-xud-docker.conf")
 
 try:
     parsed = _parse_xud_docker_conf()

--- a/images/utils/config_parser.py
+++ b/images/utils/config_parser.py
@@ -22,6 +22,8 @@ try:
 except toml.TomlDecodeError as e:
     print("Failed to parse xud-docker.conf:", e)
     exit(1)
+except:
+    pass
 
 parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
 parser.add_argument(f"--{network}-dir")

--- a/images/utils/launcher/config/xud-docker.conf
+++ b/images/utils/launcher/config/xud-docker.conf
@@ -1,4 +1,3 @@
-#home-dir = "~/.xud-docker"
 #simnet-dir = "$home_dir/simnet"
 #testnet-dir = "$home_dir/testnet"
 #mainnet-dir = "$home_dir/mainnet"


### PR DESCRIPTION
This commit will reveal xud-docker.conf parsing errors. The reason why <network>-dir is not working in xud-docker.conf is because we use "load" function which takes the file content as the filename.

Closes https://github.com/ExchangeUnion/xud-docker/issues/280