### PR TITLE
chore: update GETH to v1.9.10

### DIFF
--- a/images/utils/launcher/node/geth.py
+++ b/images/utils/launcher/node/geth.py
@@ -55,7 +55,7 @@ class Geth(Node):
 
     @property
     def image(self):
-        return "exchangeunion/geth:1.9.9"
+        return "exchangeunion/geth:1.9.10"
 
     def start(self):
         if self.external:

--- a/images/versions.ini
+++ b/images/versions.ini
@@ -10,7 +10,7 @@ node = lts-alpine ; node 10, alpine 3.9
 bitcoind = 0.19.0.1
 litecoind = 0.17.1
 lnd = lightningnetwork/lnd:v0.8.2-beta
-geth = v1.9.9
+geth = v1.9.10
 raiden = ExchangeUnion/raiden:develop
 xud = ExchangeUnion/xud:v1.0.0-beta
 
@@ -18,6 +18,6 @@ xud = ExchangeUnion/xud:v1.0.0-beta
 bitcoind = 0.19.0.1
 litecoind = 0.17.1
 lnd = 0.8.2-beta
-geth = 1.9.9
+geth = 1.9.10
 raiden = latest
 xud = 1.0.0-beta


### PR DESCRIPTION
Obligatory GETH update PR

Testing instructions:
 
* `bash xud.sh -b update-geth-1910`
* test if raiden and swaps still work

