### PR TITLE
fix: create/restore choice strict match

### DIFF
--- a/images/utils/launcher/check_wallets.py
+++ b/images/utils/launcher/check_wallets.py
@@ -228,7 +228,7 @@ class Action:
                         break
                     except:
                         pass
-                else:
+                elif reply == "2":
                     self.setup_restore_dir()
                     if self.config.restore_dir:
                         if self.config.restore_dir != "/tmp/fake-backup":


### PR DESCRIPTION
This commit strictly matches the choice number. Before this we will enter into the second choice when this reply is not "1". This could surprise the user somehow.