### PR TITLE
fix: name collision when running multiple utils containers

### DIFF
--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -7,9 +7,12 @@ import traceback
 
 from .config import Config, ArgumentError, InvalidHomeDir, InvalidNetworkDir
 from .node import NodeManager, NodeNotFound, ImagesNotAvailable
-from .check_wallets import Action as CheckWalletsAction, BackupDirNotAvailable
 from .utils import ParallelExecutionError, get_hostfs_file
 from .errors import NetworkConfigFileSyntaxError, NetworkConfigFileValueError, CommandLineArgumentValueError
+
+from .check_wallets import Action as CheckWalletsAction, BackupDirNotAvailable
+from .close_other_utils import Action as CloseOtherUtilsAction
+
 
 
 def init_logging():
@@ -100,11 +103,15 @@ your issue.""")
         # TODO wait for channels
         pass
 
+    def close_other_utils(self):
+        CloseOtherUtilsAction(self.config.network, self.shell).execute()
+
     def pre_start(self):
         if self.config.network in ["testnet", "mainnet"]:
             self.check_wallets()
         elif self.config.network == "simnet":
             self.wait_for_channels()
+        self.close_other_utils()
 
     def start(self):
         try:

--- a/images/utils/launcher/close_other_utils.py
+++ b/images/utils/launcher/close_other_utils.py
@@ -1,6 +1,6 @@
 import docker
 from docker.models.containers import Container
-from docker.errors import NotFound
+from docker.errors import APIError
 from typing import List
 from subprocess import check_output
 
@@ -32,5 +32,9 @@ class Action:
                 print(f"Removing {c.name}...")
                 try:
                     c.remove()
-                except NotFound:
-                    pass
+                except APIError as e:
+                    if e.status_code == 409:
+                        # docker.errors.APIError: 409 Client Error: Conflict ("removal of container xxx is already in progress")
+                        pass
+                    else:
+                        raise e

--- a/images/utils/launcher/close_other_utils.py
+++ b/images/utils/launcher/close_other_utils.py
@@ -57,9 +57,5 @@ class Action:
                 print(f"Removing {c.name}...")
                 try:
                     c.remove()
-                except APIError as e:
-                    if e.status_code == 409:
-                        # docker.errors.APIError: 409 Client Error: Conflict ("removal of container xxx is already in progress")
-                        pass
-                    else:
-                        raise e
+                except:
+                    pass

--- a/images/utils/launcher/close_other_utils.py
+++ b/images/utils/launcher/close_other_utils.py
@@ -1,0 +1,36 @@
+import docker
+from docker.models.containers import Container
+from docker.errors import NotFound
+from typing import List
+from subprocess import check_output
+
+
+class Action:
+    def __init__(self, network, shell):
+        self.network = network
+        self.shell = shell
+        self.client = docker.from_env()
+
+    def execute(self):
+        result: List[Container] = self.client.containers.list(all=True, filters={"name": f"{self.network}_utils"})
+        hostname = check_output("hostname").decode().splitlines()[0]
+
+        result = [c for c in result if c.attrs["Config"]["Hostname"] != hostname]
+
+        n = len(result)
+
+        if n == 0:
+            return
+
+        reply = self.shell.yes_or_no("Found {} existing xud ctl sessions. Do you want to close these?".format(n))
+        if reply == "yes":
+            for c in result:
+                if c.status == "running":
+                    print(f"Stopping {c.name}...")
+                    c.stop()
+            for c in result:
+                print(f"Removing {c.name}...")
+                try:
+                    c.remove()
+                except NotFound:
+                    pass

--- a/setup.sh
+++ b/setup.sh
@@ -256,6 +256,13 @@ function ensure_directory() {
     fi
 }
 
+function get_utils_name() {
+    local N
+    N=$(docker ps -a --filter name="${NETWORK}_utils_" --format '{{.Names}}' | sed 's/mainnet_utils_//' | sort -nr | head -n1)
+    ((N++))
+    echo "${NETWORK}_utils_${N}"
+}
+
 ################################################################################
 # MAIN
 ################################################################################
@@ -271,7 +278,7 @@ ensure_utils_image
 echo "🚀 Launching $NETWORK environment"
 
 docker run --rm -it \
---name "${NETWORK}_utils" \
+--name "$(get_utils_name)" \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /:/mnt/hostfs \
 -e HOST_PWD="$PWD" \

--- a/setup.sh
+++ b/setup.sh
@@ -258,7 +258,7 @@ function ensure_directory() {
 
 function get_utils_name() {
     local N
-    N=$(docker ps -a --filter name="${NETWORK}_utils_" --format '{{.Names}}' | sed 's/mainnet_utils_//' | sort -nr | head -n1)
+    N=$(docker ps -a --filter name="${NETWORK}_utils_" --format '{{.Names}}' | sed "s/${NETWORK}_utils_//" | sort -nr | head -n1)
     ((N++))
     echo "${NETWORK}_utils_${N}"
 }


### PR DESCRIPTION
This commit adds a number suffix to utils container name. It will auto calculate the number which is the maximum existing number plus one. And there is an interactive question before launching xudctl shell. It will prompt you like:

    Found 2 existing xud ctl sessions. Do you want to close these? [Y/n] Y
    Stopping mainnet_utils_1...
    Stopping mainnet_utils_2...
    Removing mainnet_utils_1...
    Removing mainnet_utils_2...

Closes #260