### PR TITLE
fix: xud image size

### DIFF
--- a/images/xud/1.0.0-beta.1-simnet/Dockerfile
+++ b/images/xud/1.0.0-beta.1-simnet/Dockerfile
@@ -5,12 +5,14 @@ ARG BRANCH=v1.0.0-beta.1
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 #ADD https://api.github.com/repos/$REPO/commits/$BRANCH /dev/null
-RUN git clone -b $BRANCH https://github.com/$REPO
+RUN git clone -b $BRANCH --depth=2 https://github.com/$REPO
 WORKDIR /xud
 RUN git show HEAD > git_head.txt
 RUN npm install
 RUN npm run compile
 RUN npm run compile:seedutil
+RUN npm prune --production
+RUN rm -rf seedutil/go
 
 FROM node:12-alpine3.10
 RUN apk add --no-cache bash supervisor tor

--- a/images/xud/1.0.0-beta.1-simnet/Dockerfile.aarch64
+++ b/images/xud/1.0.0-beta.1-simnet/Dockerfile.aarch64
@@ -8,13 +8,17 @@ RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 RUN apk add --no-cache python
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 #ADD https://api.github.com/repos/$REPO/commits/$BRANCH /dev/null
-RUN git clone -b $BRANCH https://github.com/$REPO
+RUN git clone -b $BRANCH --depth=2 https://github.com/$REPO
 WORKDIR /xud
 RUN git show HEAD > git_head.txt
+RUN cp package.json /tmp/package.json
 RUN sed -Ei 's/"grpc-tools": "1.8.0",//g' package.json
 RUN npm install
+RUN cp /tmp/package.json package.json
 RUN npm run compile
 RUN npm run compile:seedutil
+RUN npm prune --production
+RUN rm -rf seedutil/go
 
 FROM node:12-alpine3.10
 RUN apk add --no-cache bash supervisor tor

--- a/images/xud/1.0.0-beta.1/Dockerfile
+++ b/images/xud/1.0.0-beta.1/Dockerfile
@@ -5,12 +5,14 @@ ARG BRANCH=v1.0.0-beta.1
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 #ADD https://api.github.com/repos/$REPO/commits/$BRANCH /dev/null
-RUN git clone -b $BRANCH https://github.com/$REPO
+RUN git clone -b $BRANCH --depth=2 https://github.com/$REPO
 WORKDIR /xud
 RUN git show HEAD > git_head.txt
 RUN npm install
 RUN npm run compile
 RUN npm run compile:seedutil
+RUN npm prune --production
+RUN rm -rf seedutil/go
 
 
 FROM node:12-alpine3.10

--- a/images/xud/1.0.0-beta.1/Dockerfile.aarch64
+++ b/images/xud/1.0.0-beta.1/Dockerfile.aarch64
@@ -8,13 +8,17 @@ RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 RUN apk add --no-cache python
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 #ADD https://api.github.com/repos/$REPO/commits/$BRANCH /dev/null
-RUN git clone -b $BRANCH https://github.com/$REPO
+RUN git clone -b $BRANCH --depth=2 https://github.com/$REPO
 WORKDIR /xud
 RUN git show HEAD > git_head.txt
+RUN cp package.json /tmp/package.json
 RUN sed -Ei 's/"grpc-tools": "1.8.0",//g' package.json
 RUN npm install
+RUN cp /tmp/package.json package.json
 RUN npm run compile
 RUN npm run compile:seedutil
+RUN npm prune --production
+RUN rm -rf seedutil/go
 
 
 FROM node:12-alpine3.10


### PR DESCRIPTION
This commit shrink xud image size from ~600M to 150M. The image size blows up becuase the seedutil/go build folder is included in the final image.