### PR TITLE
feat: add mode config option

### DIFF
--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -27,11 +27,12 @@
 # 28333 - ZeroMQ raw transactions publication port (zmqpubrawtx)
 #expose-ports = ["8332", "8333", "28332", "28333"]
 
-# Set `external` option true and fill options below to enable using external
-# bitcoind node. Setting `neutrino` to true will use lnd's internal light client
-# and ignore `external` option.
-#external = false
-#neutrino = false
+# This option specifies the mode of the bitcoind node. The available values are
+# "native", "external" and "neutrino". The default value is "native". Set value
+# to "external" and fill options below to enable using external bitcoind node.
+# Setting value to "neutrino" will use lnd's internal light client and ignore
+# mode "external" related options.
+#mode = "native"
 #rpc-host = "127.0.0.1"
 #rpc-port = 8332
 #rpc-user = "xu"
@@ -50,11 +51,12 @@
 # 28333 - ZeroMQ raw transactions publication port (zmqpubrawtx)
 #expose-ports = ["9332", "9333", "29332:28332", "29333:28333"]
 
-# Set `external` option true and fill options below to enable using external
-# litecoind node. Setting `neutrino` to true will use lnd's internal light client
-# and ignore `external` option.
-#external = false
-#neutrino = false
+# This option specifies the mode of the litecoind node. The available values are
+# "native", "external" and "neutrino". The default value is "native". Set value
+# to "external" and fill options below to enable using external litecoind node.
+# Setting value to "neutrino" will use lnd's internal light client and ignore
+# mode "external" related options.
+#mode = "native"
 #rpc-host = "127.0.0.1"
 #rpc-port = 9332
 #rpc-user = "xu"
@@ -74,11 +76,15 @@
 # 30303/udp - P2P port
 #expose-ports = ["8545", "30303/udp"]
 
-# Set `external` option true and fill options below to enable using external
-# geth node.
-#external = false
+# This option specifies the mode of the geth node. The available values are
+# "native", "external" and "infura". The default value is "native". Set value to
+# "external" and fill options below to enable using external geth node.
+#mode = "native"
 #rpc-host = "127.0.0.1"
 #rpc-port = 8545
+
+# Setting `mode` option "infura" will let raiden node use Infura as a Geth API
+# provider and ignore mode "external" related options.
 #infura-project-id = ""
 #infura-project-secret = ""
 

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -27,11 +27,12 @@
 # 28333 - ZeroMQ raw transactions publication port (zmqpubrawtx)
 #expose-ports = ["18332", "18333", "28332", "28333"]
 
-# Set `external` option true and fill options below to enable using external
-# bitcoind node. Setting `neutrino` to true will use lnd's internal light client
-# and ignore `external` option.
-#external = false
-#neutrino = false
+# This option specifies the mode of the bitcoind node. The available values are
+# "native", "external" and "neutrino". The default value is "native". Set value
+# to "external" and fill options below to enable using external bitcoind node.
+# Setting value to "neutrino" will use lnd's internal light client and ignore
+# mode "external" related options.
+#mode = "native"
 #rpc-host = "127.0.0.1"
 #rpc-port = 18332
 #rpc-user = "xu"
@@ -50,11 +51,12 @@
 # 28333 - ZeroMQ raw transactions publication port (zmqpubrawtx)
 #expose-ports = ["19332", "19333", "29332:28332", "29333:28333"]
 
-# Set `external` option true and fill options below to enable using external
-# litecoind node. Setting `neutrino` to true will use lnd's internal light client
-# and ignore `external` option.
-#external = false
-#neutrino = false
+# This option specifies the mode of the litecoind node. The available values are
+# "native", "external" and "neutrino". The default value is "native". Set value
+# to "external" and fill options below to enable using external litecoind node.
+# Setting value to "neutrino" will use lnd's internal light client and ignore
+# mode "external" related options.
+#mode = "native"
 #rpc-host = "127.0.0.1"
 #rpc-port = 19332
 #rpc-user = "xu"
@@ -74,11 +76,15 @@
 # 30303/udp - P2P port
 #expose-ports = ["8545", "30303/udp"]
 
-# Set `external` option true and fill options below to enable using external
-# geth node.
-#external = false
+# This option specifies the mode of the geth node. The available values are
+# "native", "external" and "infura". The default value is "native". Set value to
+# "external" and fill options below to enable using external geth node.
+#mode = "native"
 #rpc-host = "127.0.0.1"
 #rpc-port = 8545
+
+# Setting `mode` option "infura" will let raiden node use Infura as a Geth API
+# provider and ignore mode "external" related options.
 #infura-project-id = ""
 #infura-project-secret = ""
 


### PR DESCRIPTION
This commit adds `mode` config option to bitcoind, litecoind and geth node. And it deprecates `external` and `neutrino` options.

Closes #295 