### PR TITLE
fix: two typos which cause geth custom dir not working

### DIFF
--- a/images/geth/1.9.12/entrypoint.sh
+++ b/images/geth/1.9.12/entrypoint.sh
@@ -15,8 +15,11 @@ OPTS=(
   "--rpcvhosts=*"
   "--cache=256"
   "--nousb"
-  "--datadir.ancient=$ETHEREUM_DIR/chaindata"
 )
+
+if [[ $CUSTOM_ANCIENT_CHAINDATA == "true" ]]; then
+    OPTS+=("--datadir.ancient=/root/.ethereum-ancient-chaindata")
+fi
 
 if [[ $NETWORK == "testnet" ]]; then
   OPTS+=("--testnet")

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -627,12 +627,7 @@ class Config:
 
         if "ancient-chaindata-dir" in parsed:
             value = parsed["ancient-chaindata-dir"]
-            # TODO backward compatible with /root/.ethereum/chaindata
-            if self.network == "mainnet":
-                host_dir = "/root/.ethereum/chaindata/ancient"
-            else:
-                host_dir = "/root/.ethereum/testnet/chaindata/ancient"
-            self.update_volume(node["volumes"], host_dir, value)
+            self.update_volume(node["volumes"], "/root/.ethereum-ancient-chaindata", value)
 
         self.update_ports(node, parsed)
 

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -535,7 +535,7 @@ class Config:
             })
         else:
             target = target[0]
-            target["host_dir"] = host_dir
+            target["host"] = host_dir
 
     def update_ports(self, node, parsed):
         if "expose-ports" in parsed:

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -527,7 +527,7 @@ class Config:
             self.external_ip = self.args.external_ip
 
     def update_volume(self, volumes, container_dir, host_dir):
-        target = [v for v in volumes if v["container_dir"] == container_dir]
+        target = [v for v in volumes if v["container"] == container_dir]
         if len(target) == 0:
             volumes.append({
                 "host": host_dir,

--- a/images/utils/launcher/node/geth.py
+++ b/images/utils/launcher/node/geth.py
@@ -32,12 +32,28 @@ class Geth(Node):
                 "project_secret": self.node_config["infura_project_secret"],
             }
 
+        self.container_spec.environment.extend(self.get_environment())
+
         if self.network == "testnet":
             self._cli = "geth --testnet"
         elif self.network == "mainnet":
             self._cli = "geth"
 
         self.api = GethApi(CliBackend(self.client, self.container_name, self._logger, self._cli))
+
+    def get_environment(self):
+        result = []
+        if self.use_custom_ancient_chaindata():
+            result.append("CUSTOM_ANCIENT_CHAINDATA=true")
+        else:
+            result.append("CUSTOM_ANCIENT_CHAINDATA=false")
+        return result
+
+    def use_custom_ancient_chaindata(self):
+        for v in self.node_config["volumes"]:
+            if v["container"] == "/root/.ethereum-ancient-chaindata":
+                return True
+        return False
 
     def get_external_status(self):
         s = socket.socket()


### PR DESCRIPTION
This PR fixes a typo which causes KeyError: 'container_dir' when using custom geth ancient chaindata dir.

Closes https://github.com/ExchangeUnion/xud-docker/issues/392