### PR TITLE
fix: master building all images

### DIFF
--- a/tools/helper.py
+++ b/tools/helper.py
@@ -234,10 +234,13 @@ class Image:
                             gr = self.get_github_revision(self.name, _branch)
                             print("- Registry image application: {} ({})".format(r2, _branch))
                             print("- Latest application revision: {}".format(gr))
-                            if r2 == gr:
-                                return True
+                            if gr:
+                                if r2 == gr:
+                                    return True
+                                else:
+                                    return False
                             else:
-                                return False
+                                return True
                         else:
                             return False
                     else:


### PR DESCRIPTION
This PR fixes tools scrips which build all images in every Travis build since last `xud-latest` PR merged into master.