### PR TITLE
chore: push manifest list incrementally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,5 @@ before_script:
 script: tools/push --no-manifest-list
 jobs:
   include:
-    - stage: Create and push manifest lists
-      script: tools/push --manifest-list
     - stage: Test common cases
       script: tools/test


### PR DESCRIPTION
This PR changes old travis build flow from
```
1) build foo__x86_64 and foo__aarch64
2) create foo including amd and arm
```
to
```
build foo__x86_64 and create manifest list including amd and arm or amd only
build foo__aarch64 and create manifest list including amd and arm or arm only
```