### PR TITLE
fix arm64 build failure

### DIFF
--- a/tools/helper.py
+++ b/tools/helper.py
@@ -196,11 +196,14 @@ class Image:
         else:
             return None
 
-        tag = self.get_github_tag(repo, branch)
-        if tag:
-            return tag
-        else:
-            return self.get_github_branch_revision(repo, branch)
+        try:
+            tag = self.get_github_tag(repo, branch)
+            if tag:
+                return tag
+            else:
+                return self.get_github_branch_revision(repo, branch)
+        except:
+            return None
 
     def existed_in_registry_and_up_to_date(self, registry):
         name = "{}/{}".format(self.group, self.name)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "tools/helper.py", line 188, in get_github_branch_revision
    r = urlopen(f"https://api.github.com/repos/{repo}/git/refs/heads/{branch}")
  File "/opt/python/3.8.0/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/opt/python/3.8.0/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/opt/python/3.8.0/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/opt/python/3.8.0/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/opt/python/3.8.0/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/opt/python/3.8.0/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "tools/helper.py", line 853, in <module>
    main()
  File "tools/helper.py", line 843, in main
    image.push()
  File "tools/helper.py", line 498, in push
    img.push()
  File "tools/helper.py", line 439, in push
    if self.build([]):
  File "tools/helper.py", line 378, in build
    if self.existed_in_registry_and_up_to_date(docker_registry):
  File "tools/helper.py", line 234, in existed_in_registry_and_up_to_date
    gr = self.get_github_revision(self.name, _branch)
  File "tools/helper.py", line 203, in get_github_revision
    return self.get_github_branch_revision(repo, branch)
  File "tools/helper.py", line 191, in get_github_branch_revision
    raise RuntimeError(e, "Failed to get GitHub repository {} branch {} revision".format(repo, branch))
RuntimeError: (<HTTPError 404: 'Not Found'>, 'Failed to get GitHub repository ExchangeUnion/xud branch None revision')
```