### PR TITLE
chore: change btcd/ltcd server ip to domain

### DIFF
--- a/images/utils/launcher/node/btcd.py
+++ b/images/utils/launcher/node/btcd.py
@@ -14,7 +14,7 @@ class Btcd(Node):
             "--rpcpass=xu",
             "--rpclisten=:18556",
             "--nolisten",
-            "--addpeer=35.231.222.142:39555",
+            "--addpeer=btcd.simnet.exchangeunion.com:39555",
         ]
 
         self.container_spec.command.extend(command)

--- a/images/utils/launcher/node/lnd.py
+++ b/images/utils/launcher/node/lnd.py
@@ -42,7 +42,7 @@ class Lnd(Node):
             return []
         if self.chain == "bitcoin":
             # TODO better to have --alias
-            # nohup lnd-btc --noseedbackup --rpclisten=127.0.0.1:10002 --listen=127.0.0.1:10012 --restlisten=8002 --datadir=./data --logdir=./logs  --nobootstrap --no-macaroons --bitcoin.active --bitcoin.simnet  --btcd.rpcuser=xu --btcd.rpcpass=xu --debuglevel=debug --alias="BTC@$xname" --btcd.rpchost=127.0.0.1:18556  --btcd.rpccert=$cert --bitcoin.node neutrino  --neutrino.connect 35.231.222.142:38555 --chan-enable-timeout=0m10s --max-cltv-expiry=5000 > /dev/null 2>&1 &
+            # nohup lnd-btc --noseedbackup --rpclisten=127.0.0.1:10002 --listen=127.0.0.1:10012 --restlisten=8002 --datadir=./data --logdir=./logs  --nobootstrap --no-macaroons --bitcoin.active --bitcoin.simnet  --btcd.rpcuser=xu --btcd.rpcpass=xu --debuglevel=debug --alias="BTC@$xname" --btcd.rpchost=127.0.0.1:18556  --btcd.rpccert=$cert --bitcoin.node neutrino  --neutrino.connect btcd.simnet.exchangeunion.com:38555 --chan-enable-timeout=0m10s --max-cltv-expiry=5000 > /dev/null 2>&1 &
             return [
                 "--debuglevel=debug",
                 "--nobootstrap",
@@ -52,12 +52,12 @@ class Lnd(Node):
                 "--bitcoin.simnet",
                 "--bitcoin.node=neutrino",
                 "--bitcoin.defaultchanconfs=6",
-                "--neutrino.connect=35.231.222.142:38555",
+                "--neutrino.connect=btcd.simnet.exchangeunion.com:38555",
                 "--chan-enable-timeout=0m10s",
                 "--max-cltv-expiry=5000",
             ]
         if self.chain == "litecoin":
-            # nohup lnd-ltc --noseedbackup --rpclisten=127.0.0.1:10001 --listen=127.0.0.1:10011 --restlisten=8001 --datadir=./data --logdir=./logs --nobootstrap --no-macaroons --litecoin.active --litecoin.simnet --debuglevel=debug --alias="LTC@$xname" --litecoin.node neutrino --neutrino.connect 35.231.222.142:39555 --chan-enable-timeout=0m10s --max-cltv-expiry=20000 > /dev/null 2>&1 &
+            # nohup lnd-ltc --noseedbackup --rpclisten=127.0.0.1:10001 --listen=127.0.0.1:10011 --restlisten=8001 --datadir=./data --logdir=./logs --nobootstrap --no-macaroons --litecoin.active --litecoin.simnet --debuglevel=debug --alias="LTC@$xname" --litecoin.node neutrino --neutrino.connect btcd.simnet.exchangeunion.com:39555 --chan-enable-timeout=0m10s --max-cltv-expiry=20000 > /dev/null 2>&1 &
             return [
                 "--debuglevel=debug",
                 "--nobootstrap",
@@ -67,7 +67,7 @@ class Lnd(Node):
                 "--litecoin.simnet",
                 "--litecoin.node=neutrino",
                 "--litecoin.defaultchanconfs=6",
-                "--neutrino.connect=35.231.222.142:39555",
+                "--neutrino.connect=btcd.simnet.exchangeunion.com:39555",
                 "--chan-enable-timeout=0m10s",
                 "--max-cltv-expiry=20000",
             ]

--- a/images/utils/launcher/node/raiden.py
+++ b/images/utils/launcher/node/raiden.py
@@ -40,14 +40,14 @@ class Raiden(Node):
         user_deposit = "0x19f8B656fBf17a83a5023eEbd675B1Ae5Bb5dF50"
         monitoring_service = "0x3B26A3d3D0c262359d1807863aE0D0FB6831D081"
         one_to_n = "0x7337e831cF5BD75B0045050E6C6549cf914A923D"
-        #raiden --datadir $datadir --keystore-path $keystore  --network-id 4321 --accept-disclaimer --address $address --rpc --api-address 0.0.0.0:5001 --environment-type $env  --password-file $passwd_file --no-sync-check --accept-disclaimer --tokennetwork-registry-contract-address $TokenNetworkRegistry --secret-registry-contract-address $SecretRegistry  --gas-price 10000000000 --eth-rpc-endpoint 35.231.222.142:8546  --matrix-server https://raidentransport.exchangeunion.com --resolver-endpoint http://localhost:8887/resolveraiden --service-registry-contract-address $ServiceRegistry --one-to-n-contract-address $OneToN --user-deposit-contract-address $UserDeposit --monitoring-service-contract-address $MonitoringService --routing-mode private
+        #raiden --datadir $datadir --keystore-path $keystore  --network-id 4321 --accept-disclaimer --address $address --rpc --api-address 0.0.0.0:5001 --environment-type $env  --password-file $passwd_file --no-sync-check --accept-disclaimer --tokennetwork-registry-contract-address $TokenNetworkRegistry --secret-registry-contract-address $SecretRegistry  --gas-price 10000000000 --eth-rpc-endpoint btcd.simnet.exchangeunion.com:8546  --matrix-server https://raidentransport.exchangeunion.com --resolver-endpoint http://localhost:8887/resolveraiden --service-registry-contract-address $ServiceRegistry --one-to-n-contract-address $OneToN --user-deposit-contract-address $UserDeposit --monitoring-service-contract-address $MonitoringService --routing-mode private
         command = [
             "--environment-type development",
             "--routing-mode private",
             "--network-id 4321",
             "--no-sync-check",
             "--gas-price 10000000000",
-            "--eth-rpc-endpoint 35.231.222.142:8546",
+            "--eth-rpc-endpoint btcd.simnet.exchangeunion.com:8546",
             "--tokennetwork-registry-contract-address {}".format(token_network_registry),
             "--secret-registry-contract-address {}".format(secret_registry),
             "--matrix-server https://raidentransport.exchangeunion.com",


### PR DESCRIPTION
This commit changes the btcd/ltcd simnet ip to use a domain instead so
that in case of the ip change only the DNS entry needs to be updated.

Test:
```
bash xud.sh -b chore/use-domain-for-btcd-ltcd
```
...and ensure that BTC/LTC simnet chains are working.