### PR TITLE
fix(launcher): unindented updates with cancellation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -207,11 +207,23 @@ function ensure_utils_image() {
     fi
 
     case $STATUS in
-        missing|outdated)
+        missing)
             if [[ -n $P_IMG ]]; then
                 pull_image "$P_IMG"
                 if [[ $BRANCH != "master" && ! $P_IMG =~ __ ]]; then
                     echo "Warning: Branch image $B_IMG not found. Fallback to $P_IMG"
+                fi
+            fi
+            ;;
+        outdated)
+            if [[ -n $P_IMG ]]; then
+                read -p "The utils image is outdated. Would you like to pull the new image? [Y/n]" -n 1 -r
+                echo  # move to a new line
+                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                    pull_image "$P_IMG"
+                    if [[ $BRANCH != "master" && ! $P_IMG =~ __ ]]; then
+                        echo "Warning: Branch image $B_IMG not found. Fallback to $P_IMG"
+                    fi
                 fi
             fi
             ;;


### PR DESCRIPTION
The unintended updates of the old environment was due to the force pulling of utils images when it it missing or outdated. This commit added an interactive question before pulling the images when it is outdated.

This is the simplest way to fix the unindented updates issue because it didn't touch the whole utils logic at all. But this introduces an extra update question which is a little bit wired than a normal application. So please feel free to leave some comments about this fix.

This PR closes https://github.com/ExchangeUnion/xud-docker/issues/358

### How to test this PR?

1. Try to generate a new utils image on the cloud
2. Run xud script you should see the question:
```
The utils image is outdated. Would you like to pull the new image? [Y/n]
```

N.B. If the utils image is missing the question won't appear. If the local image is newer than the cloud one the old warning will show btw:
```
Warning: Use local $B_IMG (newer than cloud $P_IMG)
```
