### PR TITLE
chore: update xud-docker link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Discord](https://img.shields.io/discord/547402601885466658.svg)](https://discord.gg/YgDhMSn)
 [![Docker Pulls](https://img.shields.io/docker/pulls/exchangeunion/xud)](https://hub.docker.com/r/exchangeunion/xud)
 
-A complete [xud](https://github.com/ExchangeUnion/xud) environment using [docker](https://www.docker.com/). Get started trading using xud-docker 👉 [here](https://docs.exchangeunion.com/start-earning/market-maker-guide#the-setup) 👈
+A complete [xud](https://github.com/ExchangeUnion/xud) environment using [docker](https://www.docker.com/) targeted at market makers. Follow the 👉 [market maker guide](https://docs.exchangeunion.com/start-earning/market-maker-guide) 👈!
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Discord](https://img.shields.io/discord/547402601885466658.svg)](https://discord.gg/YgDhMSn)
 [![Docker Pulls](https://img.shields.io/docker/pulls/exchangeunion/xud)](https://hub.docker.com/r/exchangeunion/xud)
 
-A complete [xud](https://github.com/ExchangeUnion/xud) environment using [docker](https://www.docker.com/). Get started trading using xud-docker 👉 [here](https://docs.exchangeunion.com/start-trading/user-guide) 👈
+A complete [xud](https://github.com/ExchangeUnion/xud) environment using [docker](https://www.docker.com/). Get started trading using xud-docker 👉 [here](https://docs.exchangeunion.com/start-earning/market-maker-guide#the-setup) 👈
 
 ## Developing
 


### PR DESCRIPTION
Update link from 
https://docs.exchangeunion.com/start-trading/user-guide
to
https://docs.exchangeunion.com/start-earning/market-maker-guide#the-setup
since market makers are the target user group of xud-docker