### PR TITLE
feat(xudctl): add confirmation before down command

### DIFF
--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -180,9 +180,6 @@ class NodeManager:
             self.wait_for_channels()
 
     def down(self):
-        reply = self.shell.yes_or_no("Are you sure to shutdown your xud environment (this will cancel all open orders)?")
-        if reply == "no":
-            return
         for name, container in self.nodes.items():
             print(f"Stopping {name}...")
             container.stop()

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -180,6 +180,9 @@ class NodeManager:
             self.wait_for_channels()
 
     def down(self):
+        reply = self.shell.yes_or_no("Are you sure to shutdown your xud environment (this will cancel all open orders)?")
+        if reply == "no":
+            return
         for name, container in self.nodes.items():
             print(f"Stopping {name}...")
             container.stop()

--- a/images/utils/launcher/shell/shell.py
+++ b/images/utils/launcher/shell/shell.py
@@ -389,6 +389,9 @@ class InputHandler(threading.Thread):
                     if not cmd.is_empty():
                         if cmd.is_exit():
                             return False
+                        elif str(cmd) == "down":
+                            self._handle_command(str(cmd))
+                            return False
                         else:
                             self._handle_command(str(cmd))
                             self._history_commit(cmd)  # will reset history too


### PR DESCRIPTION
This PR adds a confirmation question before xudctl `down` command.

```
Are you sure to shutdown your xud environment (this will cancel all open orders)? [Y/n]
```

Closes #304