### PR TITLE
chore(launcher): refine config parsing errors

### DIFF
--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -139,7 +139,6 @@ class Launcher:
 
     def launch(self):
         shell = Shell()
-        exit_code = 0
         config = None
         try:
             config = Config(ConfigLoader())
@@ -149,18 +148,14 @@ class Launcher:
             env.start()
         except KeyboardInterrupt:
             print()
-            exit_code = 1
         except FatalError as e:
             if config and config.logfile:
                 print(f"❌ Error: {e}. For more details, see {config.logfile}")
             else:
                 traceback.print_exc()
-            exit_code = 1
         except Exception:  # exclude system exceptions like SystemExit
             self.logger.exception("Unexpected exception during launching")
             traceback.print_exc()
-            exit_code = 1
         finally:
             shell.stop()
-        exit(exit_code)
 

--- a/images/utils/launcher/errors.py
+++ b/images/utils/launcher/errors.py
@@ -1,2 +1,19 @@
+from enum import Enum
+from typing import Optional
+
+
 class FatalError(Exception):
     pass
+
+
+class ConfigErrorScope(Enum):
+    COMMAND_LINE_ARGS = 0
+    GENERAL_CONF = 1
+    NETWORK_CONF = 2
+
+
+class ConfigError(Exception):
+    def __init__(self, scope: ConfigErrorScope, conf_file: Optional[str] = None):
+        super().__init__(scope)
+        self.scope = scope
+        self.conf_file = conf_file


### PR DESCRIPTION
Closes #252

**Examples:**
```
❌ Failed to parse command-line arguments, exiting.
Error details: unrecognized arguments: --foo

❌ Failed to parse config file /home/yy/.xud-docker/xud-docker.conf, exiting.
Error details: Found invalid character in key name: '*'. Try quoting the key name. (line 4 column 4 char 106)

❌ Failed to parse config file /home/yy/.xud-docker/simnet/simnet.conf, exiting.
Error details: Found invalid character in key name: '$'. Try quoting the key name. (line 37 column 3 char 1014)
```