### PR TITLE
chore: remove image timestamp comparison

### DIFF
--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -109,6 +109,8 @@ class Config:
         parser.add_argument("--arby.margin")
         parser.add_argument("--arby.disabled", nargs='?')
 
+        parser.add_argument("--use-local-images")
+
         self.args = parser.parse_args()
         self.logger.info("Parsed command-line arguments: %r", self.args)
 
@@ -494,6 +496,14 @@ class Config:
             value = getattr(self.args, opt).strip()
             if len(value) > 0:
                 self.backup_dir = value
+
+        opt = "use_local_images"
+        if hasattr(self.args, opt):
+            value = getattr(self.args, opt).strip()
+            parts = value.split(",")
+            parts = [p.strip() for p in parts]
+            for p in parts:
+                self.nodes[p]["use_local_image"] = True
 
         for node in self.nodes.values():
             name = node["name"]

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -69,6 +69,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "lndltc": {
             "name": "lndltc",
@@ -82,6 +83,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "connext": {
             "name": "connext",
@@ -95,6 +97,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "arby": {
             "name": "arby",
@@ -113,6 +116,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "disabled": True,
+            "use_local_image": False,
         },
         "xud": {
             "name": "xud",
@@ -138,6 +142,7 @@ nodes_config = {
             "ports": [PortPublish("28885")],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         }
     },
     "testnet": {
@@ -159,6 +164,7 @@ nodes_config = {
             "external_zmqpubrawblock": "127.0.0.1:28332",
             "external_zmqpubrawtx": "127.0.0.1:28333",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "litecoind": {
             "name": "litecoind",
@@ -178,6 +184,7 @@ nodes_config = {
             "external_zmqpubrawblock": "127.0.0.1:29332",
             "external_zmqpubrawtx": "127.0.0.1:29333",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "geth": {
             "name": "geth",
@@ -197,6 +204,7 @@ nodes_config = {
             "preserve_config": False,
             "eth_provider": None,
             "cache": 256,
+            "use_local_image": False,
         },
         "lndbtc": {
             "name": "lndbtc",
@@ -210,6 +218,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "lndltc": {
             "name": "lndltc",
@@ -223,6 +232,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "connext": {
             "name": "connext",
@@ -236,6 +246,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "arby": {
             "name": "arby",
@@ -254,6 +265,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "disabled": True,
+            "use_local_image": False,
         },
         "xud": {
             "name": "xud",
@@ -279,6 +291,7 @@ nodes_config = {
             "ports": [PortPublish("18885")],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         }
     },
     "mainnet": {
@@ -300,6 +313,7 @@ nodes_config = {
             "external_zmqpubrawblock": "127.0.0.1:28332",
             "external_zmqpubrawtx": "127.0.0.1:28333",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "litecoind": {
             "name": "litecoind",
@@ -319,6 +333,7 @@ nodes_config = {
             "external_zmqpubrawblock": "127.0.0.1:29332",
             "external_zmqpubrawtx": "127.0.0.1:29333",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "geth": {
             "name": "geth",
@@ -337,6 +352,7 @@ nodes_config = {
             "infura_project_secret": None,
             "preserve_config": False,
             "cache": 256,
+            "use_local_image": False,
         },
         "lndbtc": {
             "name": "lndbtc",
@@ -350,6 +366,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "lndltc": {
             "name": "lndltc",
@@ -363,6 +380,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "connext": {
             "name": "connext",
@@ -376,6 +394,7 @@ nodes_config = {
             "ports": [],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         },
         "arby": {
             "name": "arby",
@@ -394,6 +413,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "disabled": True,
+            "use_local_image": False,
         },
         "xud": {
             "name": "xud",
@@ -419,6 +439,7 @@ nodes_config = {
             "ports": [PortPublish("8885")],
             "mode": "native",
             "preserve_config": False,
+            "use_local_image": False,
         }
     }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -164,15 +164,7 @@ function get_image_status() {
         return
     fi
 
-    L_CREATED=$(echo "$LOCAL" | sed -n '2p')
-    C_CREATED=$(echo "$CLOUD" | sed -n '2p')
-
-    if [[ $L_CREATED > $C_CREATED ]]; then
-        U_IMG=$B_IMG
-        echo "newer $B_IMG $U_IMG $P_IMG"
-    else
-        echo "outdated $B_IMG $U_IMG $P_IMG"
-    fi
+    echo "outdated $B_IMG $U_IMG $P_IMG"
 }
 
 function pull_image() {


### PR DESCRIPTION
EDIT: this removes the faulty timestamp comparison for the local xud-docker setup to check if a local image needs to be updated with a newer available image in the docker cloud. It now follows the simple principle of *only* comparing mage hashes (digests). If the hash in the docker cloud is **different**, it prompts to to update.

The following pseudo code describes the behavior:
```
        if can't get hash from cloud
            retry (don't return null) up until 30s timeout
        if can't get hash from local:
            local.digest=null (new environment)
        if local.hash == cloud.hash:
            return "UP_TO_DATE"
        else:
            pull
```