### PR TITLE
tools: forcefully build without manifest checking

### DIFF
--- a/tools/core/toolkit.py
+++ b/tools/core/toolkit.py
@@ -121,6 +121,7 @@ class Toolkit:
               dry_run: bool = False,
               no_cache: bool = False,
               cross_build: bool = False,
+              force: bool = False,
               ) -> None:
 
         self._logger.debug("Build with images=%r, dry_run=%r, no_cache=%r, cross_build=%r",
@@ -135,10 +136,10 @@ class Toolkit:
 
         if images:
             for name in images:
-                Image(ctx, name).build(no_cache=no_cache)
+                Image(ctx, name).build(no_cache=no_cache, force=force)
         else:
             for image in self.git_template.get_modified_images(ctx):
-                image.build(no_cache=no_cache)
+                image.build(no_cache=no_cache, force=force)
 
     def push(self,
              images: List[str] = None,

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -12,6 +12,7 @@ def main():
     build_parser.add_argument("--dry-run", action="store_true")
     build_parser.add_argument("--cross-build", action="store_true")
     build_parser.add_argument("--no-cache", action="store_true")
+    build_parser.add_argument("-f", "--force", action="store_true")
     build_parser.add_argument("images", type=str, nargs="*")
 
     push_parser = subparsers.add_parser("push")
@@ -33,7 +34,7 @@ def main():
     toolkit = Toolkit(project_dir, ["linux/amd64", "linux/arm64"])
 
     if args.command == "build":
-        toolkit.build(args.images, args.dry_run, args.no_cache, args.cross_build)
+        toolkit.build(args.images, args.dry_run, args.no_cache, args.cross_build, args.force)
     elif args.command == "push":
         toolkit.push(args.images, args.dry_run, args.no_cache, args.cross_build, args.dirty_push)
     elif args.command == "test":


### PR DESCRIPTION
This PR adds option `-f` and `--force` to `tools/build` command. 

The redundant image pulling and tagging are also removed in this PR. See https://github.com/ExchangeUnion/xud-docker/pull/546/files#diff-8a792fef7c99bb820b9a2bbfe2d0d532L207-L212