### PR TITLE
Disable autopilot on simnet lnds

### DIFF
--- a/images/lnd/0.10.1-beta-simnet/Dockerfile
+++ b/images/lnd/0.10.1-beta-simnet/Dockerfile
@@ -16,7 +16,7 @@ RUN patch lnd.go /patches/lnd.patch
 RUN patch vendor/github.com/lightninglabs/neutrino/blockmanager.go /patches/neutrino.patch
 RUN sed -i.bak "s/\!w.isDevEnv/w.isDevEnv/" vendor/github.com/btcsuite/btcwallet/wallet/wallet.go
 # build
-RUN go install -v -mod=vendor -tags="autopilotrpc chainrpc experimental invoicesrpc routerrpc signrpc walletrpc watchtowerrpc wtclientrpc" -ldflags "-X github.com/lightningnetwork/lnd/build.Commit=$VERSION-simnet" ./cmd/lnd ./cmd/lncli
+RUN go install -v -mod=vendor -tags="chainrpc experimental invoicesrpc routerrpc signrpc walletrpc watchtowerrpc wtclientrpc" -ldflags "-X github.com/lightningnetwork/lnd/build.Commit=$VERSION-simnet" ./cmd/lnd ./cmd/lncli
 RUN strip /go/bin/lnd /go/bin/lncli
 
 

--- a/images/lnd/0.9.0-beta-ltc-simnet/Dockerfile
+++ b/images/lnd/0.9.0-beta-ltc-simnet/Dockerfile
@@ -17,7 +17,7 @@ RUN patch lnd.go /patches/lnd.patch
 RUN patch vendor/github.com/ltcsuite/neutrino/blockmanager.go /patches/neutrino.patch
 RUN sed -i.bak "s/\!w.isDevEnv/w.isDevEnv/" vendor/github.com/ltcsuite/ltcwallet/wallet/wallet.go
 # build
-RUN go install -v -mod=vendor -tags="autopilotrpc chainrpc experimental invoicesrpc routerrpc signrpc walletrpc watchtowerrpc wtclientrpc" -ldflags "-X github.com/ltcsuite/lnd/build.Commit=$VERSION-ltc-simnet" ./cmd/lnd ./cmd/lncli
+RUN go install -v -mod=vendor -tags="chainrpc experimental invoicesrpc routerrpc signrpc walletrpc watchtowerrpc wtclientrpc" -ldflags "-X github.com/ltcsuite/lnd/build.Commit=$VERSION-ltc-simnet" ./cmd/lnd ./cmd/lncli
 RUN strip /go/bin/lnd /go/bin/lncli
 
 

--- a/images/utils/launcher/node/lnd.py
+++ b/images/utils/launcher/node/lnd.py
@@ -57,7 +57,7 @@ class Lnd(Node):
                 "--neutrino.connect=btcd.simnet.exchangeunion.com:38555",
                 "--chan-enable-timeout=0m10s",
                 "--max-cltv-expiry=5000",
-                "--autopilot.active=false",
+                "--autopilot.active false",
             ]
         if self.chain == "litecoin":
             # nohup lnd-ltc --noseedbackup --rpclisten=127.0.0.1:10001 --listen=127.0.0.1:10011 --restlisten=8001 --datadir=./data --logdir=./logs --nobootstrap --no-macaroons --litecoin.active --litecoin.simnet --debuglevel=debug --alias="LTC@$xname" --litecoin.node neutrino --neutrino.connect btcd.simnet.exchangeunion.com:39555 --chan-enable-timeout=0m10s --max-cltv-expiry=20000 > /dev/null 2>&1 &
@@ -74,7 +74,7 @@ class Lnd(Node):
                 "--neutrino.connect=btcd.simnet.exchangeunion.com:39555",
                 "--chan-enable-timeout=0m10s",
                 "--max-cltv-expiry=20000",
-                "--autopilot.active=false",
+                "--autopilot.active false",
             ]
 
     def get_environment(self):

--- a/images/utils/launcher/node/lnd.py
+++ b/images/utils/launcher/node/lnd.py
@@ -57,7 +57,6 @@ class Lnd(Node):
                 "--neutrino.connect=btcd.simnet.exchangeunion.com:38555",
                 "--chan-enable-timeout=0m10s",
                 "--max-cltv-expiry=5000",
-                "--autopilot.active false",
             ]
         if self.chain == "litecoin":
             # nohup lnd-ltc --noseedbackup --rpclisten=127.0.0.1:10001 --listen=127.0.0.1:10011 --restlisten=8001 --datadir=./data --logdir=./logs --nobootstrap --no-macaroons --litecoin.active --litecoin.simnet --debuglevel=debug --alias="LTC@$xname" --litecoin.node neutrino --neutrino.connect btcd.simnet.exchangeunion.com:39555 --chan-enable-timeout=0m10s --max-cltv-expiry=20000 > /dev/null 2>&1 &
@@ -74,7 +73,6 @@ class Lnd(Node):
                 "--neutrino.connect=btcd.simnet.exchangeunion.com:39555",
                 "--chan-enable-timeout=0m10s",
                 "--max-cltv-expiry=20000",
-                "--autopilot.active false",
             ]
 
     def get_environment(self):


### PR DESCRIPTION
Finally:
```
kilrau@raspixud:~$ docker logs -f simnet_lndbtc_1 | grep autopilot
2020-06-19 10:38:19.251 [INF] ATPL: Instantiating autopilot with active=false, max_channels=5, allocation=0.600000, min_chan_size=20000, max_chan_size=4294967295, private=false, min_confs=1, conf_target=3
```
lndltc still activates it though and it's not obvious why since config is 1:1 with lndbtc, so I hope this will be fixed with upgrade to 0.10.1:
```
kilrau@raspixud:~$ docker logs -f simnet_lndltc_1 | grep autopilot
2020-06-19 10:38:17.834 [INF] ATPL: Instantiating autopilot with max_channels=5, allocation=0.600000, min_chan_size=20000, max_chan_size=4294967295, private=false, min_confs=1, conf_target=3
```