### PR TITLE
Add arby configuration options

### DIFF
--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -425,7 +425,7 @@ class Config:
             if parsed["test-centralized-quoteasset-balance"]:
                 value = parsed["test-centralized-quoteasset-balance"]
                 node["test-centralized-quoteasset-balance"] = value
-        opt = "arby.test-centralized-quoteasset-balance"
+        opt = "arby.test_centralized_quoteasset_balance"
         if hasattr(self.args, opt):
             value = getattr(self.args, opt)
             if value:

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -104,6 +104,8 @@ class Config:
         parser.add_argument("--connext.expose-ports")
         parser.add_argument("--xud.expose-ports")
 
+        parser.add_argument("--arby.test-centralized-baseasset-balance")
+        parser.add_argument("--arby.test-centralized-quoteasset-balance")
         parser.add_argument("--arby.binance-api-key")
         parser.add_argument("--arby.binance-api-secret")
         parser.add_argument("--arby.margin")
@@ -409,6 +411,26 @@ class Config:
         :param parsed: Parsed xud TOML section
         """
         node = self.nodes["arby"]
+        if "test-centralized-baseasset-balance" in parsed:
+            if parsed["test-centralized-baseasset-balance"]:
+                value = parsed["test-centralized-baseasset-balance"]
+                node["test-centralized-baseasset-balance"] = value
+        opt = "arby.test-centralized-baseasset-balance"
+        if hasattr(self.args, opt):
+            value = getattr(self.args, opt)
+            if value:
+                node["test-centralized-baseasset-balance"] = value
+
+        if "test-centralized-quoteasset-balance" in parsed:
+            if parsed["test-centralized-quoteasset-balance"]:
+                value = parsed["test-centralized-quoteasset-balance"]
+                node["test-centralized-quoteasset-balance"] = value
+        opt = "arby.test-centralized-quoteasset-balance"
+        if hasattr(self.args, opt):
+            value = getattr(self.args, opt)
+            if value:
+                node["test-centralized-quoteasset-balance"] = value
+
         if "binance-api-key" in parsed:
             if parsed["binance-api-key"]:
                 value = parsed["binance-api-key"]

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -415,7 +415,7 @@ class Config:
             if parsed["test-centralized-baseasset-balance"]:
                 value = parsed["test-centralized-baseasset-balance"]
                 node["test-centralized-baseasset-balance"] = value
-        opt = "arby.test-centralized-baseasset-balance"
+        opt = "arby.test_centralized_baseasset_balance"
         if hasattr(self.args, opt):
             value = getattr(self.args, opt)
             if value:

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -121,6 +121,8 @@
 #expose-ports = ["8885", "8886", "8080"]
 
 [arby]
+#test-centralized-baseasset-balance = "123"
+#test-centralized-quoteasset-balance = "321"
 #binance-api-key = "your api key"
 #binance-api-secret = "your api secret"
 #margin = "0.04"

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -34,6 +34,8 @@
 #expose-ports = ["28885", "28886", "28080:8080"]
 
 [arby]
+#test-centralized-baseasset-balance = "123"
+#test-centralized-quoteasset-balance = "321"
 #binance-api-key = "your api key"
 #binance-api-secret = "your api secret"
 #margin = "0.04"

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -121,6 +121,8 @@
 #expose-ports = ["18885", "18886", "18080:8080"]
 
 [arby]
+#test-centralized-baseasset-balance = "123"
+#test-centralized-quoteasset-balance = "321"
 #binance-api-key = "your api key"
 #binance-api-secret = "your api secret"
 #margin = "0.04"

--- a/images/utils/launcher/node/arby.py
+++ b/images/utils/launcher/node/arby.py
@@ -41,6 +41,7 @@ class Arby(Node):
             f"OPENDEX_RPC_PORT={rpc_port}",
             f'BINANCE_API_SECRET={api_secret}',
             f'BINANCE_API_KEY={api_key}',
+            f'MARGIN={margin}',
             f'TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE={test_centralized_baseasset_balance}',
             f'TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE={test_centralized_quoteasset_balance}',
         ]

--- a/images/utils/launcher/node/arby.py
+++ b/images/utils/launcher/node/arby.py
@@ -19,6 +19,10 @@ class Arby(Node):
             if "binance-api-secret" in self.node_config else "abc"
         margin = self.node_config["margin"] \
             if "margin" in self.node_config else "0.04"
+        test_centralized_baseasset_balance = self.node_config["test-centralized-baseasset-balance"] \
+            if "test-centralized-baseasset-balance" in self.node_config else "123"
+        test_centralized_quoteasset_balance = self.node_config["test-centralized-quoteasset-balance"] \
+            if "test-centralized-baseasset-balance" in self.node_config else "321"
 
         if self.network == "simnet":
             rpc_port = "28886"
@@ -37,7 +41,8 @@ class Arby(Node):
             f"OPENDEX_RPC_PORT={rpc_port}",
             f'BINANCE_API_SECRET={api_secret}',
             f'BINANCE_API_KEY={api_key}',
-            f'MARGIN={margin}',
+            f'TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE={test_centralized_baseasset_balance}',
+            f'TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE={test_centralized_quoteasset_balance}',
         ]
 
         self.container_spec.environment.extend(environment)


### PR DESCRIPTION
This PR adds `test-centralized-baseasset-balance` and `test-centralized-quoteasset-balance`
configuration options to the arby section of the config.

These values are used as the mock centralized exchange base/quoteasset balance when arby is running in testing mode.