### PR TITLE
chore(boltz): add shortcuts for boltzcli deposit/withdraw

### DIFF
--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -91,6 +91,8 @@ your issue.""")
             elif arg0 == "boltzcli":
                 self.node_manager.cli("boltz", *args)
             elif arg0 == "deposit":
+                if len(args) == 0:
+                    print("Missing chain")
                 chain = args[0]
                 args = args[1:]
                 if chain == "btc":
@@ -98,6 +100,8 @@ your issue.""")
                 elif chain == "ltc":
                     self.node_manager.cli("boltz", "ltc", "deposit", *args)
             elif arg0 == "withdraw":
+                if len(args) == 0:
+                    print("Missing chain")
                 chain = args[0]
                 args = args[1:]
                 if chain == "btc":

--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -90,6 +90,20 @@ your issue.""")
                 self.node_manager.cli("xud", *args)
             elif arg0 == "boltzcli":
                 self.node_manager.cli("boltz", *args)
+            elif arg0 == "deposit":
+                chain = args[0]
+                args = args[1:]
+                if chain == "btc":
+                    self.node_manager.cli("boltz", "boltzcli", "btc", "deposit", *args)
+                elif chain == "ltc":
+                    self.node_manager.cli("boltz", "boltzcli", "ltc", "deposit", *args)
+            elif arg0 == "withdraw":
+                chain = args[0]
+                args = args[1:]
+                if chain == "btc":
+                    self.node_manager.cli("boltz", "boltzcli", "btc", "withdraw", *args)
+                elif chain == "ltc":
+                    self.node_manager.cli("boltz", "boltzcli", "ltc", "withdraw", *args)
             else:
                 self.delegate_cmd_to_xucli(cmd)
         except NodeNotFound as e:

--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -94,16 +94,16 @@ your issue.""")
                 chain = args[0]
                 args = args[1:]
                 if chain == "btc":
-                    self.node_manager.cli("boltz", "boltzcli", "btc", "deposit", *args)
+                    self.node_manager.cli("boltz", "btc", "deposit", *args)
                 elif chain == "ltc":
-                    self.node_manager.cli("boltz", "boltzcli", "ltc", "deposit", *args)
+                    self.node_manager.cli("boltz", "ltc", "deposit", *args)
             elif arg0 == "withdraw":
                 chain = args[0]
                 args = args[1:]
                 if chain == "btc":
-                    self.node_manager.cli("boltz", "boltzcli", "btc", "withdraw", *args)
+                    self.node_manager.cli("boltz", "btc", "withdraw", *args)
                 elif chain == "ltc":
-                    self.node_manager.cli("boltz", "boltzcli", "ltc", "withdraw", *args)
+                    self.node_manager.cli("boltz", "ltc", "withdraw", *args)
             else:
                 self.delegate_cmd_to_xucli(cmd)
         except NodeNotFound as e:


### PR DESCRIPTION
This PR adds two shortcut commands for boltzcli

* `deposit btc/ltc ...` (`boltzcli btc/ltc deposit ...`)
* `withdraw btc/ltc ...` (`boltzcli btc/ltc withdraw ...`)

Closes #565