### PR TITLE
feat: add arby live CEX mode option

### DIFF
--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -104,6 +104,7 @@ class Config:
         parser.add_argument("--connext.expose-ports")
         parser.add_argument("--xud.expose-ports")
 
+        parser.add_argument("--arby.live-cex")
         parser.add_argument("--arby.test-centralized-baseasset-balance")
         parser.add_argument("--arby.test-centralized-quoteasset-balance")
         parser.add_argument("--arby.binance-api-key")
@@ -430,6 +431,16 @@ class Config:
             value = getattr(self.args, opt)
             if value:
                 node["test-centralized-quoteasset-balance"] = value
+
+        if "live-cex" in parsed:
+            if parsed["live-cex"]:
+                value = parsed["live-cex"]
+                node["live-cex"] = value
+        opt = "arby.live_cex"
+        if hasattr(self.args, opt):
+            value = getattr(self.args, opt)
+            if value:
+                node["live-cex"] = value
 
         if "binance-api-key" in parsed:
             if parsed["binance-api-key"]:

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -121,6 +121,7 @@
 #expose-ports = ["8885", "8886", "8080"]
 
 [arby]
+#live-cex="false"
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #binance-api-key = "your api key"

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -34,6 +34,7 @@
 #expose-ports = ["28885", "28886", "28080:8080"]
 
 [arby]
+#live-cex="false"
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #binance-api-key = "your api key"

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -121,6 +121,7 @@
 #expose-ports = ["18885", "18886", "18080:8080"]
 
 [arby]
+#live-cex="false"
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #binance-api-key = "your api key"

--- a/images/utils/launcher/node/arby.py
+++ b/images/utils/launcher/node/arby.py
@@ -13,6 +13,8 @@ class Arby(Node):
     def __init__(self, name, ctx):
         super().__init__(name, ctx)
 
+        live_cex = self.node_config["live-cex"] \
+            if "live-cex" in self.node_config else "false"
         api_key = self.node_config["binance-api-key"] \
             if "binance-api-key" in self.node_config else "123"
         api_secret = self.node_config["binance-api-secret"] \
@@ -41,6 +43,7 @@ class Arby(Node):
             f"OPENDEX_RPC_PORT={rpc_port}",
             f'BINANCE_API_SECRET={api_secret}',
             f'BINANCE_API_KEY={api_key}',
+            f'LIVE_CEX={live_cex}',
             f'MARGIN={margin}',
             f'TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE={test_centralized_baseasset_balance}',
             f'TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE={test_centralized_quoteasset_balance}',


### PR DESCRIPTION
This PR adds a new configuration `live-cex` option to arby which enables:
- fetching real balances from a centralized exchange
- executing market buy and sell orders on CEX after a successful swap

The minimum for buy/sell orders is 0.005 ETH.

To enable live CEX mode:
```
[arby]
#live-cex="true"
#binance-api-key = "your api key"
#binance-api-secret = "your api secret"
```

Test:
`bash xud.sh -b arby/live-mode`