### PR TITLE
feat: add webui

### DIFF
--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -394,10 +394,17 @@ class Config:
         self.update_ports(node, parsed)
 
     def update_connext(self, parsed):
-        """Update Connext related configurations from parsed TOML raiden section
+        """Update Connext related configurations from parsed TOML connext section
         :param parsed: Parsed raiden TOML section
         """
         node = self.nodes["connext"]
+        self.update_ports(node, parsed)
+
+    def update_webui(self, parsed):
+        """Update webui related configurations from parsed TOML webui section
+        :param parsed: Parsed raiden TOML section
+        """
+        node = self.nodes.get("webui", None)
         self.update_ports(node, parsed)
 
     def update_raiden(self, parsed):

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -118,6 +118,7 @@ class Config:
         parser.add_argument("--webui.expose-ports")
 
         parser.add_argument("--dev", action="store_true")
+        parser.add_argument("--use-local-images")
 
         self.args = parser.parse_args()
         self.logger.info("Parsed command-line arguments: %r", self.args)

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -116,6 +116,7 @@ class Config:
 
         parser.add_argument("--use-local-images")
         parser.add_argument("--dev", action="store_true")
+        parser.add_argument("--webui", action="store_true")
 
         self.args = parser.parse_args()
         self.logger.info("Parsed command-line arguments: %r", self.args)
@@ -406,6 +407,11 @@ class Config:
         """
         node = self.nodes.get("webui", None)
         self.update_ports(node, parsed)
+
+        opt = "webui"
+        if hasattr(self.args, opt):
+            value = getattr(self.args, opt)
+            node["disabled"] = False
 
     def update_raiden(self, parsed):
         """Update raiden related configurations from parsed TOML raiden section

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -128,3 +128,7 @@
 #binance-api-secret = "your api secret"
 #margin = "0.04"
 #disabled = false
+
+[webui]
+#disabled = false
+#expose-ports = ["8888"]

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -131,4 +131,4 @@
 
 [webui]
 #disabled = false
-#expose-ports = ["8888"]
+#expose-ports = ["8888:8080"]

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -131,3 +131,4 @@
 
 [webui]
 #disabled = false
+#expose-ports = ["8888"]

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -131,4 +131,3 @@
 
 [webui]
 #disabled = false
-#expose-ports = ["8888"]

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -41,3 +41,7 @@
 #binance-api-secret = "your api secret"
 #margin = "0.04"
 #disabled = false
+
+[webui]
+#disabled = false
+#expose-ports = ["28888"]

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -44,3 +44,4 @@
 
 [webui]
 #disabled = false
+#expose-ports = ["28888"]

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -44,4 +44,3 @@
 
 [webui]
 #disabled = false
-#expose-ports = ["28888"]

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -44,4 +44,4 @@
 
 [webui]
 #disabled = false
-#expose-ports = ["28888"]
+#expose-ports = ["28888:8080"]

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -127,7 +127,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [],
+            "ports": [PortPublish("28888:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -314,7 +314,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [],
+            "ports": [PortPublish("18888:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -500,7 +500,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [],
+            "ports": [PortPublish("8888:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -333,7 +333,12 @@ nodes_config = {
         "webui": {
             "name": "webui",
             "image": "exchangeunion/webui:latest",
-            "volumes": [],
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
             "ports": [PortPublish("8080")],
             "mode": "native",
             "preserve_config": False,
@@ -513,7 +518,12 @@ nodes_config = {
         "webui": {
             "name": "webui",
             "image": "exchangeunion/webui:latest",
-            "volumes": [],
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
             "ports": [PortPublish("8080")],
             "mode": "native",
             "preserve_config": False,

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -118,6 +118,21 @@ nodes_config = {
             "disabled": True,
             "use_local_image": False,
         },
+        "webui": {
+            "name": "webui",
+            "image": "exchangeunion/webui:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+            "disabled": True,
+        },
         "xud": {
             "name": "xud",
             "image": "exchangeunion/xud:latest",
@@ -143,21 +158,6 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
-        },
-        "webui": {
-            "name": "webui",
-            "image": "exchangeunion/webui:latest",
-            "volumes": [
-                {
-                    "host": "$data_dir/xud",
-                    "container": "/root/.xud",
-                }
-            ],
-            "ports": [],
-            "mode": "native",
-            "preserve_config": False,
-            "use_local_image": False,
-            "disabled": True,
         },
     },
     "testnet": {
@@ -305,6 +305,21 @@ nodes_config = {
             "disabled": False,
             "use_local_image": False,
         },
+        "webui": {
+            "name": "webui",
+            "image": "exchangeunion/webui:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+            "disabled": True,
+        },
         "xud": {
             "name": "xud",
             "image": "exchangeunion/xud:latest",
@@ -331,21 +346,6 @@ nodes_config = {
             "preserve_config": False,
             "use_local_image": False,
         },
-        "webui": {
-            "name": "webui",
-            "image": "exchangeunion/webui:latest",
-            "volumes": [
-                {
-                    "host": "$data_dir/xud",
-                    "container": "/root/.xud",
-                }
-            ],
-            "ports": [],
-            "mode": "native",
-            "preserve_config": False,
-            "use_local_image": False,
-            "disabled": True,
-        }
     },
     "mainnet": {
         "bitcoind": {
@@ -491,6 +491,21 @@ nodes_config = {
             "disabled": False,
             "use_local_image": False,
         },
+        "webui": {
+            "name": "webui",
+            "image": "exchangeunion/webui:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+            "disabled": True,
+        },
         "xud": {
             "name": "xud",
             "image": "exchangeunion/xud:1.0.0-beta.4",
@@ -517,21 +532,6 @@ nodes_config = {
             "preserve_config": False,
             "use_local_image": False,
         },
-        "webui": {
-            "name": "webui",
-            "image": "exchangeunion/webui:latest",
-            "volumes": [
-                {
-                    "host": "$data_dir/xud",
-                    "container": "/root/.xud",
-                }
-            ],
-            "ports": [],
-            "mode": "native",
-            "preserve_config": False,
-            "use_local_image": False,
-            "disabled": True,
-        }
     }
 }
 

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -143,7 +143,21 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
-        }
+        },
+        "webui": {
+            "name": "webui",
+            "image": "exchangeunion/webui:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [PortPublish("8080")],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+        },
     },
     "testnet": {
         "bitcoind": {
@@ -315,6 +329,15 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
+        },
+        "webui": {
+            "name": "webui",
+            "image": "exchangeunion/webui:latest",
+            "volumes": [],
+            "ports": [PortPublish("8080")],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
         }
     },
     "mainnet": {
@@ -483,6 +506,15 @@ nodes_config = {
                 },
             ],
             "ports": [PortPublish("8885")],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+        },
+        "webui": {
+            "name": "webui",
+            "image": "exchangeunion/webui:latest",
+            "volumes": [],
+            "ports": [PortPublish("8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -153,7 +153,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [PortPublish("8080")],
+            "ports": [],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -340,7 +340,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [PortPublish("8080")],
+            "ports": [],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -526,7 +526,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [PortPublish("8080")],
+            "ports": [],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -157,6 +157,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
+            "disabled": True,
         },
     },
     "testnet": {
@@ -343,6 +344,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
+            "disabled": True,
         }
     },
     "mainnet": {
@@ -528,6 +530,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
+            "disabled": True,
         }
     }
 }

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -134,4 +134,4 @@
 
 [webui]
 #disabled = false
-#expose-ports = ["18888"]
+#expose-ports = ["18888:8080"]

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -134,3 +134,4 @@
 
 [webui]
 #disabled = false
+#expose-ports = ["18888"]

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -131,3 +131,7 @@
 
 [boltz]
 #disabled = false
+
+[webui]
+#disabled = false
+#expose-ports = ["18888"]

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -134,4 +134,3 @@
 
 [webui]
 #disabled = false
-#expose-ports = ["18888"]

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -19,6 +19,7 @@ from .connext import Connext
 from .geth import Geth
 from .image import Image, ImageManager
 from .lnd import Lndbtc, Lndltc
+from .webui import Webui
 from .xud import Xud, XudApiError
 from ..config import Config
 from ..errors import FatalError

--- a/images/utils/launcher/node/webui.py
+++ b/images/utils/launcher/node/webui.py
@@ -1,0 +1,9 @@
+from .base import Node
+
+
+class Webui(Node):
+    def __init__(self, name, ctx):
+        super().__init__(name, ctx)
+
+    def status(self):
+        return "Ready"

--- a/images/webui/latest/Dockerfile
+++ b/images/webui/latest/Dockerfile
@@ -23,4 +23,6 @@ COPY --from=builder /src/backend/bin /app/bin
 COPY --from=builder /src/frontend/build /app/public
 COPY entrypoint.sh /
 WORKDIR /app
-ENTRYPOINT ["/entrypoint.sh"]
+RUN apk --no-cache add supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/images/webui/latest/Dockerfile
+++ b/images/webui/latest/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add git
 
 RUN git clone -b socketio https://github.com/ExchangeUnion/xud-webui-poc /src/frontend
 WORKDIR /src/frontend
-RUN git fetch && git checkout 69abd2ac
+RUN git fetch && git checkout b94cb330
 RUN yarn install
 RUN yarn build
 

--- a/images/webui/latest/Dockerfile
+++ b/images/webui/latest/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add git
 
 RUN git clone -b socketio https://github.com/ExchangeUnion/xud-webui-poc /src/frontend
 WORKDIR /src/frontend
-RUN git fetch && git checkout b1f1083d
+RUN git fetch && git checkout f3d34f02
 RUN yarn install
 RUN yarn build
 

--- a/images/webui/latest/Dockerfile
+++ b/images/webui/latest/Dockerfile
@@ -10,6 +10,7 @@ RUN yarn build
 RUN git clone -b dev https://github.com/ExchangeUnion/xud-socketio /src/backend
 WORKDIR /src/backend
 RUN git fetch && git checkout 186cbb38
+RUN sed -Ei 's/^.*grpc-tools.*$//g' package.json
 RUN yarn install
 RUN apk --no-cache add bash
 RUN yarn build

--- a/images/webui/latest/Dockerfile
+++ b/images/webui/latest/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:14-alpine as builder
+RUN apk --no-cache add git
+
+RUN git clone -b socketio https://github.com/ExchangeUnion/xud-webui-poc /src/frontend
+WORKDIR /src/frontend
+RUN git fetch && git checkout b1f1083d
+RUN yarn install
+RUN yarn build
+
+RUN git clone -b dev https://github.com/ExchangeUnion/xud-socketio /src/backend
+WORKDIR /src/backend
+RUN git fetch && git checkout 186cbb38
+RUN yarn install
+RUN apk --no-cache add bash
+RUN yarn build
+
+
+FROM node:14-alpine
+COPY --from=builder /src/backend/node_modules /app/node_modules
+COPY --from=builder /src/backend/dist /app/dist
+COPY --from=builder /src/backend/bin /app/bin
+COPY --from=builder /src/frontend/build /app/public
+COPY entrypoint.sh /
+WORKDIR /app
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/webui/latest/Dockerfile
+++ b/images/webui/latest/Dockerfile
@@ -3,13 +3,13 @@ RUN apk --no-cache add git
 
 RUN git clone -b socketio https://github.com/ExchangeUnion/xud-webui-poc /src/frontend
 WORKDIR /src/frontend
-RUN git fetch && git checkout f3d34f02
+RUN git fetch && git checkout fa70b2ba
 RUN yarn install
 RUN yarn build
 
 RUN git clone -b dev https://github.com/ExchangeUnion/xud-socketio /src/backend
 WORKDIR /src/backend
-RUN git fetch && git checkout 186cbb38
+RUN git fetch && git checkout a3fd8648
 RUN sed -Ei 's/^.*grpc-tools.*$//g' package.json
 RUN yarn install
 RUN apk --no-cache add bash

--- a/images/webui/latest/Dockerfile.aarch64
+++ b/images/webui/latest/Dockerfile.aarch64
@@ -24,4 +24,6 @@ COPY --from=builder /src/backend/bin /app/bin
 COPY --from=builder /src/frontend/build /app/public
 COPY entrypoint.sh /
 WORKDIR /app
-ENTRYPOINT ["/entrypoint.sh"]
+RUN apk --no-cache add supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/images/webui/latest/Dockerfile.aarch64
+++ b/images/webui/latest/Dockerfile.aarch64
@@ -3,7 +3,7 @@ RUN apk --no-cache add git
 
 RUN git clone -b socketio https://github.com/ExchangeUnion/xud-webui-poc /src/frontend
 WORKDIR /src/frontend
-RUN git fetch && git checkout 69abd2ac
+RUN git fetch && git checkout b94cb330
 RUN yarn install
 RUN yarn build
 

--- a/images/webui/latest/Dockerfile.aarch64
+++ b/images/webui/latest/Dockerfile.aarch64
@@ -11,6 +11,7 @@ RUN git clone -b dev https://github.com/ExchangeUnion/xud-socketio /src/backend
 WORKDIR /src/backend
 RUN git fetch && git checkout a3fd8648
 RUN sed -Ei 's/^.*grpc-tools.*$//g' package.json
+RUN apk --no-cache add python3 make g++
 RUN yarn install
 RUN apk --no-cache add bash
 RUN yarn build

--- a/images/webui/latest/entrypoint.sh
+++ b/images/webui/latest/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+case $NETWORK in
+    simnet)
+        RPCPORT=28886
+        ;;
+    testnet)
+        RPCPORT=18886
+        ;;
+    mainnet)
+        RPCPORT=8886
+        ;;
+    *)
+        echo "Invalid NETWORK"
+        exit 1
+esac
+
+while ! [ -e /root/.xud/tls.cert ]; do
+    echo "Waiting for /root/.xud/tls.cert"
+    sleep 1
+done
+
+exec bin/server --xud.rpchost=xud --xud.rpcport=$RPCPORT --xud.rpccert=/root/.xud/tls.cert

--- a/images/webui/latest/supervisord.conf
+++ b/images/webui/latest/supervisord.conf
@@ -1,0 +1,11 @@
+[supervisord]
+nodaemon=true
+logfile=/supervisord.log
+childlogdir=/app
+user=root
+
+[program:webui]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+command=/entrypoint.sh
+stopsignal=SIGINT

--- a/images/xud/latest/entrypoint.sh
+++ b/images/xud/latest/entrypoint.sh
@@ -108,5 +108,8 @@ cat $XUD_CONF
 
 /xud-backup.sh &
 
+echo '[entrypoint] Detecting localnet IP for xud...'
+XUD_IP=$(getent hosts xud || echo '' | awk '{ print $1 }')
+
 # use exec to properly respond to SIGINT
-exec xud $@
+exec xud --rpc.tlsextradomains xud --rpc.tlsextraips "$XUD_IP" $@

--- a/images/xud/latest/entrypoint.sh
+++ b/images/xud/latest/entrypoint.sh
@@ -108,8 +108,5 @@ cat $XUD_CONF
 
 /xud-backup.sh &
 
-echo '[entrypoint] Detecting localnet IP for xud...'
-XUD_IP=$(getent hosts xud || echo '' | awk '{ print $1 }')
-
 # use exec to properly respond to SIGINT
-exec xud --rpc.tlsextradomains xud --rpc.tlsextraips "$XUD_IP" $@
+exec xud $@

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ pytest-html
 pytest-integration
 pytest-timeout
 pytest-dotenv
+toml
+demjson


### PR DESCRIPTION
This PR adds xud-webui-poc (ReactJS based frontend) and xud-socketio (NodeJS based backend) into one container `webui`. And the container will expose port 8080 to your host. The frontend app uses REST + Websocket (socketio) API to get the order book of different trading pairs. The backend server translates the REST + Websocket API to gRPC calls and send it back to xud container.

### How to test?

Run `bash setup.sh -b webui --webui`, then you should see a web UI in http://localhost:8080 like below. And it will auto-update when orders changed.
<img width="959" alt="Screen Shot 2020-07-02 at 11 43 01 AM" src="https://user-images.githubusercontent.com/4723958/86421411-895c3480-bd0c-11ea-91c3-c59b1e9808e4.png">


### Known issues:

- [x] Disable webui by default. Add an option like `--webui` to enable it.
- [x] Decimal point alignment

EDIT: closes https://github.com/ExchangeUnion/xud/issues/1495, closes https://github.com/ExchangeUnion/xud/issues/1661
