### PR TITLE
tools: fix connext build

### DIFF
--- a/images/connext/latest/Dockerfile
+++ b/images/connext/latest/Dockerfile
@@ -4,7 +4,7 @@ ARG BRANCH=master
 RUN apk add --no-cache git bash python3 make g++ python
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 ADD https://api.github.com/repos/$REPO/commits/$BRANCH /dev/null
-RUN git clone -b $BRANCH --depth=2 https://github.com/$REPO /connext
+RUN git clone -b $BRANCH https://github.com/$REPO /connext
 WORKDIR /connext
 # lock connext container down to specific commit hash
 RUN git checkout f66093525b5f64a9dcbb1a29ebe64517bdc0698b

--- a/tools/core/application_metadata/common.py
+++ b/tools/core/application_metadata/common.py
@@ -35,9 +35,14 @@ def get_git_revision_branch(project_repo: str, builder_tag: str) -> Tuple[str, s
     revision = lines[0]
     refs = lines[1].split(", ")
     # e.g. HEAD, tag: v1.0.0-beta.4
-    branch = [ref for ref in refs if (ref.startswith("origin/") or ref.startswith("tag: "))and "HEAD" not in ref][0]
-    branch = branch.replace("origin/", "")
-    branch = branch.replace("tag: ", "")
+    targets = [ref for ref in refs if (ref.startswith("origin/") or ref.startswith("tag: "))and "HEAD" not in ref]
+    if len(targets) > 0:
+        branch = targets[0]
+        branch = branch.replace("origin/", "")
+        branch = branch.replace("tag: ", "")
+    else:
+        # FIXME parse BRANCH from Dockerfile
+        branch = "master"
     return revision, branch
 
 


### PR DESCRIPTION
This PR fixed a common error when building connext "reference not found in the tree". It's because we only clone 2 depth of the connext repository and we checkout the commit more than 2 commits before its latest HEAD. This PR also fixed `get_application_metadata` function "index out of array" error. It becuase when building connext `git checkout` will result in `git show HEAD` only shows reference name `HEAD` which we cannot infer the branch from.