### PR TITLE
tools: fix building multiple images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,17 @@ services:
 before_script:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - pip install -r requirements-dev.txt
-script:
-  - tools/push bitcoind:0.20.0
-  - tools/push litecoind:0.18.1
-  - tools/push geth:1.9.16
-  - tools/push lnd:0.10.1-beta-ltc
-  - tools/push lnd:0.10.1-beta-ltc-simnet
-  - tools/push lnd:0.10.2-beta
-  - tools/push lnd:0.10.2-beta-simnet
-  - tools/push connext
-  - tools/push connext:7.0.0-alpha.14
-  - tools/push xud
-  - tools/push xud:1.0.0-beta.5
-  - tools/push arby
-  - tools/push arby:0.2.0
-  - tools/push boltz
-  - tools/push boltz:1.0.0
-  - tools/push webui
-  - tools/push webui:1.0.0
-#script: tools/push bitcoind:0.20.0 litecoind:0.18.1 geth:1.9.16
+script: >-
+  tools/push bitcoind:0.20.0 litecoind:0.18.1 geth:1.9.16 \
+  lnd:0.10.1-beta-ltc \
+  lnd:0.10.1-beta-ltc-simnet \
+  lnd:0.10.2-beta \
+  lnd:0.10.2-beta-simnet \
+  connext connext:7.0.0-alpha.14 \
+  xud xud:1.0.0-beta.5 \
+  arby arby:0.2.0 \
+  boltz boltz:1.0.0 \
+  webui webui:1.0.0
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,13 @@ before_script:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - pip install -r requirements-dev.txt
 script: >-
-  tools/push bitcoind:0.20.0 litecoind:0.18.1 geth:1.9.16 \
-  lnd:0.10.1-beta-ltc \
-  lnd:0.10.1-beta-ltc-simnet \
-  lnd:0.10.2-beta \
-  lnd:0.10.2-beta-simnet \
-  connext connext:7.0.0-alpha.14 \
-  xud xud:1.0.0-beta.5 \
-  arby arby:0.2.0 \
-  boltz boltz:1.0.0 \
+  tools/push bitcoind:0.20.0 litecoind:0.18.1 geth:1.9.16
+  lnd:0.10.2-beta lnd:0.10.2-beta-simnet
+  lnd:0.10.1-beta-ltc lnd:0.10.1-beta-ltc-simnet
+  connext connext:7.0.0-alpha.14
+  xud xud:1.0.0-beta.5
+  arby arby:0.2.0
+  boltz boltz:1.0.0
   webui webui:1.0.0
 notifications:
   webhooks:

--- a/tools/build
+++ b/tools/build
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-set -euo pipefail
-
-cd "$(dirname "$0")"
-
-python3 helper.py build "$@"
+python $(dirname "$0")/helper.py build "$@"

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -1,0 +1,3 @@
+@echo off
+set TOOLS_DIR=%~dp0
+python %TOOLS_DIR%helper.py build %*

--- a/tools/core/__init__.py
+++ b/tools/core/__init__.py
@@ -1,4 +1,8 @@
 from .toolkit import Toolkit
 import logging
+import os
 
-logging.basicConfig(filename="tools.log", level=logging.DEBUG)
+logfile = os.path.join(os.path.dirname(os.path.dirname(__file__)), "tools.log")
+FORMAT = "%(asctime)s [%(levelname)s] %(message)s"
+
+logging.basicConfig(filename=logfile, level=logging.DEBUG, format=FORMAT, filemode="w")

--- a/tools/core/docker.py
+++ b/tools/core/docker.py
@@ -74,7 +74,7 @@ class Platforms:
     @staticmethod
     def get_current() -> Platform:
         m = platform.machine()
-        if m == "x86_64":
+        if m == "x86_64" or m == "AMD64":
             return LINUX_AMD64
         elif m == "aarch64":
             return LINUX_ARM64

--- a/tools/core/image.py
+++ b/tools/core/image.py
@@ -289,7 +289,8 @@ class Image:
             os.chdir(self.image_folder)
 
     def push(self, platform: Platform, no_cache: bool = False, dirty_push: bool = False, force: bool = False) -> None:
-        self.build(platform = platform, no_cache=no_cache, force=force)
+        if not self.build(platform = platform, no_cache=no_cache, force=force):
+            return
 
         tag = self.get_build_tag(self.branch, platform)
         cmd = "docker push {}".format(tag)

--- a/tools/core/image.py
+++ b/tools/core/image.py
@@ -169,9 +169,11 @@ class Image:
 
         def f():
             nonlocal stop
+            counter = 0
             while not stop.is_set():
+                counter = counter + 1
                 if "TRAVIS_BRANCH" in os.environ:
-                    print("Still building...")
+                    print("Still building... ({})".format(counter), flush=True)
                     stop.wait(10)
                     continue
                 print(".", end="", flush=True)

--- a/tools/core/image.py
+++ b/tools/core/image.py
@@ -22,6 +22,7 @@ class Image:
     def __init__(self, context: Context, name: str):
         self.context = context
         p = re.compile(r"^(.+):(.+)$")
+        name = name.strip()
         m = p.match(name)
         if m:
             self.name = m.group(1)

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -9,19 +9,19 @@ def main():
     parser.add_argument("-d", "--debug", action="store_true")
     subparsers = parser.add_subparsers(dest="command")
 
-    build_parser = subparsers.add_parser("build")
+    build_parser = subparsers.add_parser("build", prog="build")
     build_parser.add_argument("--dry-run", action="store_true")
-    build_parser.add_argument("--cross-build", action="store_true")
     build_parser.add_argument("--no-cache", action="store_true")
     build_parser.add_argument("-f", "--force", action="store_true")
+    build_parser.add_argument("--platform", action="append")
     build_parser.add_argument("images", type=str, nargs="*")
 
     push_parser = subparsers.add_parser("push")
     push_parser.add_argument("--dirty-push", action="store_true")
     push_parser.add_argument("--dry-run", action="store_true")
-    push_parser.add_argument("--cross-build", action="store_true")
     push_parser.add_argument("--no-cache", action="store_true")
     push_parser.add_argument("-f", "--force", action="store_true")
+    push_parser.add_argument("--platform", action="append")
     push_parser.add_argument("images", type=str, nargs="*")
 
     subparsers.add_parser("test")
@@ -38,9 +38,9 @@ def main():
     sys.path.append(".")
 
     if args.command == "build":
-        toolkit.build(args.images, args.dry_run, args.no_cache, args.cross_build, args.force)
+        toolkit.build(args.images, args.dry_run, args.no_cache, args.force, args.platform)
     elif args.command == "push":
-        toolkit.push(args.images, args.dry_run, args.no_cache, args.cross_build, args.dirty_push, args.force)
+        toolkit.push(args.images, args.dry_run, args.no_cache, args.force, args.platform, args.dirty_push)
     elif args.command == "test":
         toolkit.test()
     elif args.command == "release":

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 import os
 import sys
 from core import Toolkit
+from subprocess import CalledProcessError
 
 
 def main():
@@ -52,3 +53,12 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         print()
+    except CalledProcessError as e:
+        print("$ %s" % e.cmd)
+        print("[Exit Code]\n%s" % e.returncode)
+        print("[Output]")
+        if e.stdout:
+            print(e.stdout.decode(), flush=True)
+        print("[Error]")
+        if e.stderr:
+            print(e.stderr.decode(), flush=True)

--- a/tools/push
+++ b/tools/push
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-set -euo pipefail
-
-cd "$(dirname "$0")"
-
-python3 helper.py push "$@"
+python $(dirname "$0")/helper.py push "$@"

--- a/tools/push.bat
+++ b/tools/push.bat
@@ -1,0 +1,3 @@
+@echo off
+set TOOLS_DIR=%~dp0
+python %TOOLS_DIR%helper.py push %*

--- a/tools/release
+++ b/tools/release
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-set -euo pipefail
-
-cd "$(dirname "$0")"
-
-python3 helper.py release "$@"
+python $(dirname "$0")/helper.py release "$@"

--- a/tools/release.bat
+++ b/tools/release.bat
@@ -1,0 +1,3 @@
+@echo off
+set TOOLS_DIR=%~dp0
+python %TOOLS_DIR%helper.py release %*

--- a/tools/test
+++ b/tools/test
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-set -euo pipefail
-
-cd "$(dirname "$0")"
-
-python3 helper.py test "$@"
+python $(dirname "$0")/helper.py test "$@"

--- a/tools/test.bat
+++ b/tools/test.bat
@@ -1,0 +1,3 @@
+@echo off
+set TOOLS_DIR=%~dp0
+python %TOOLS_DIR%helper.py test %*


### PR DESCRIPTION
This commit fixes the overlapped imported src module when building multiple images. And we replaced `--cross-build` with `--platform`. You can specify more than one platform with multiple `--platform` options like `--platform linux/amd64 --platform linux/arm64`. If no `--platform` specified, then the current platform will be used. This commit also simplifies the output with `Build image:tag (arch)` message only. You can see more building details from tools/tools.log.

### How to test

```
tools/build -f xud arby:0.2.0
```