### PR TITLE
feat(webui): reorder pairs (eth_btc, ltc_btc)

### DIFF
--- a/images/webui/entrypoint.sh
+++ b/images/webui/entrypoint.sh
@@ -20,4 +20,5 @@ while ! [ -e /root/.xud/tls.cert ]; do
     sleep 1
 done
 
-exec bin/server --xud.rpchost=xud --xud.rpcport=$RPCPORT --xud.rpccert=/root/.xud/tls.cert
+exec bin/server --xud.rpchost=xud --xud.rpcport=$RPCPORT --xud.rpccert=/root/.xud/tls.cert \
+--pairs.weight eth_btc:2,ltc_btc:1

--- a/images/webui/src.py
+++ b/images/webui/src.py
@@ -16,7 +16,7 @@ class SourceManager(src.SourceManager):
             self.checkout_repo(self.backend_dir, "master")
         elif version == "1.0.0":
             self.checkout_repo(self.frontend_dir, "v1.0.0")
-            self.checkout_repo(self.backend_dir, "v1.0.0")
+            self.checkout_repo(self.backend_dir, "v1.1.0")
 
     def get_application_revision(self, version):
         r1 = self.get_revision(self.frontend_dir)


### PR DESCRIPTION
This PR updates `webui:1.0.0` image backend to v1.1.0. So the new `--pairs-weight` option will be available. We use this option to reorder the frontend trading pairs from

```
ltc_btc, eth_btc
```

to

```
eth_btc, ltc_btc
```

### How to test?

Wait for new `webui:1.0.0` pushed.

```
bash xud.sh --webui.disabled=false
```

1. Select Mainnet
2. Clean up your browser local storage on http://localhost:8888. 
3. You should see `ETH/BTC` show up by default.