### PR TITLE
feat(arby): restart when exit code 0

### DIFF
--- a/images/arby/supervisord.conf
+++ b/images/arby/supervisord.conf
@@ -9,3 +9,4 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 command=/app/entrypoint.sh
 stopsignal=SIGINT
+autorestart=true


### PR DESCRIPTION
Previously supervisor would restart arby only if the exit code was unexpected (non 0). This PR changes it so that regardless of the exit code the process will be restarted.