### PR TITLE
fix: update decline in a simple way

### DIFF
--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -227,12 +227,16 @@ your issue.""")
         self.close_other_utils()
 
     def start(self):
+        up_env = True
         try:
-            self.node_manager.update()
+            up_env = self.node_manager.update()
         except ParallelExecutionError:
             pass
-        self.node_manager.up()
-        self.pre_start()
+
+        if up_env:
+            self.node_manager.up()
+            self.pre_start()
+
         self.shell.start(f"{self.config.network} > ", self.handle_command)
 
 

--- a/images/utils/launcher/node/DockerTemplate.py
+++ b/images/utils/launcher/node/DockerTemplate.py
@@ -10,6 +10,6 @@ class DockerTemplate:
 
     def get_container(self, name: str) -> Optional[Container]:
         try:
-            self.client.containers.get(name)
+            return self.client.containers.get(name)
         except docker.errors.NotFound:
             return None

--- a/images/utils/launcher/node/DockerTemplate.py
+++ b/images/utils/launcher/node/DockerTemplate.py
@@ -1,0 +1,15 @@
+import docker
+import docker.errors
+from docker.models.containers import Container
+from typing import Optional
+
+
+class DockerTemplate:
+    def __init__(self):
+        self.client = docker.from_env()
+
+    def get_container(self, name: str) -> Optional[Container]:
+        try:
+            self.client.containers.get(name)
+        except docker.errors.NotFound:
+            return None

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -297,6 +297,7 @@ class NodeManager:
             # 2.2) recreate outdated containers
             for container, result in container_check_result.items():
                 container.update(result)
+            return True
         else:
             return False
 

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -281,7 +281,7 @@ class NodeManager:
 
         all_containers_missing = functools.reduce(lambda a, b: a and b[0] in ["missing", "external", "disabled"], container_check_result.values(), True)
 
-        if all_containers_missing:
+        if all_containers_missing and self.newly_installed:
             answer = "yes"
         else:
             answer = self.shell.yes_or_no("A new version is available. Would you like to upgrade (Warning: this may restart your environment and cancel all open orders)?")

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -219,9 +219,9 @@ class NodeManager:
         diff_keys = [key for key, value in details.items() if not value.same]
         return ", ".join(diff_keys)
 
-    def update(self):
+    def update(self) -> bool:
         if self.config.disable_update:
-            return
+            return True
 
         outdated = False
 
@@ -277,7 +277,7 @@ class NodeManager:
 
         if not outdated:
             print("All up-to-date.")
-            return
+            return True
 
         all_containers_missing = functools.reduce(lambda a, b: a and b[0] in ["missing", "external", "disabled"], container_check_result.values(), True)
 
@@ -297,6 +297,8 @@ class NodeManager:
             # 2.2) recreate outdated containers
             for container, result in container_check_result.items():
                 container.update(result)
+        else:
+            return False
 
     def logs(self, *args):
         self.cmd_logs.execute(args)

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -329,14 +329,15 @@ class NodeManager:
 
     def _get_status_nodes(self):
         optional_nodes = ["arby", "boltz", "webui"]
-        result = []
-        for node in self.nodes:
+        result = {}
+        for node in self.nodes.values():
             if node.name in optional_nodes:
-                c = self.docker_template.get_container(f"{self.network}_{node.name}_1")
+                c = self.docker_template.get_container(node.container_name)
+                print(node.name, node.container_name, c)
                 if c:
-                    result.append(node)
+                    result[node.name] = node
             else:
-                result.append(node)
+                result[node.name] = node
         return result
 
     def status(self):

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -333,7 +333,6 @@ class NodeManager:
         for node in self.nodes.values():
             if node.name in optional_nodes:
                 c = self.docker_template.get_container(node.container_name)
-                print(node.name, node.container_name, c)
                 if c:
                     result[node.name] = node
             else:


### PR DESCRIPTION
This PR implement a very simple fix for update decline by just bypassing ensuring all services are up and running and any post actions. If the user declines the update he will enter into the xud-ctl shell directly.

The edge cases:
1. If the new setup removes some image and it is stopped or removed in current environment, then there is no way to bring it back automatically. And on the other side, if the new setup removes some service but the old setup keep it running, then this service needs to manually stop and remove.
2. If your setup is up-to-date then you will use the new utils (setup) to ensure all services are up and do post actions. This could be error prone.

**UPDATE**

A significant change was made in "preview! fix false update (down/up case)" which introduced a new concept "snapshot" in xud-docker. The updates were calculated by differentiating two snapshots since this commit. And the next important fix was "fix setup.sh" which brings the utils into *update checking* stage. After these two major fixes, the above two edge cases were resolved. But it has changed some fundamental logic in xud-docker. So it took so much time to do regression testing. And even now I cannot make myself believe all cases are covered.

So in order to finish this PR soon, we got two options

1) Revoke all changes since "preview! fix false update (down/up case)" and accept an imperfect solution with some failing cases in @raladev comments

> environment up-to-date, one container was stopped (connext) -> connext still is stopped VS connext up w/o any question --- FAILED

> environment up-to-date, all containers stopped (except of xud) -> all containers still are stopped VS they up without any question --- FAILED

> environment up-to-date, one container was stopped (xud) -> xud still is stopped VS question about ports update --- FAILED

This one was fixed by commit "fix ports diff"

2) Keep going with current "perfect" solution and it definitely needs more time to make it stable.