### PR TITLE
feat: all-in-one help

### DIFF
--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -16,31 +16,6 @@ from .errors import FatalError, ConfigError, ConfigErrorScope
 
 
 HELP = """\
-General commands
-  status                                    show service status
-  report                                    report issue
-  logs                                      show service log
-  start                                     start service
-  stop                                      stop service
-  restart                                   restart service
-  down                                      shutdown the environment
-  up                                        bring up the environment
-  help                                      show this help
-  exit                                      exit xud-ctl shell
-
-CLI commands
-  bitcoin-cli                               bitcoind cli
-  litecoin-cli                              litecoind cli
-  lndbtc-lncli                              lnd cli
-  lndltc-lncli                              lnd cli
-  geth                                      geth cli
-  xucli                                     xud cli
-  boltzcli                                  boltz cli
-
-Boltzcli shortcut commands
-  deposit                                   deposit from boltz
-  withdraw                                  withdraw to boltz
-
 Xucli shortcut commands
   addcurrency <currency>                    add a currency
   <swap_client> [decimal_places]
@@ -90,6 +65,34 @@ Xucli shortcut commands
                                             xud
   walletwithdraw [amount] [currency]        withdraws on-chain funds from xud
   [destination] [fee]
+  
+General commands
+  status                                    show service status
+  report                                    report issue
+  logs                                      show service log
+  start                                     start service
+  stop                                      stop service
+  restart                                   restart service
+  down                                      shutdown the environment
+  up                                        bring up the environment
+  help                                      show this help
+  exit                                      exit xud-ctl shell
+
+CLI commands
+  bitcoin-cli                               bitcoind cli
+  litecoin-cli                              litecoind cli
+  lndbtc-lncli                              lnd cli
+  lndltc-lncli                              lnd cli
+  geth                                      geth cli
+  xucli                                     xud cli
+  boltzcli                                  boltz cli
+
+Boltzcli shortcut commands  
+  deposit <chain> deposit 
+  --inbound [inbound_balance]               deposit from boltz (btc/ltc)
+  boltzcli <chain> withdraw 
+  <amount> <address>                        withdraw from boltz channel
+  
 """
 
 

--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -15,6 +15,84 @@ from .warm_up import Action as WarmUpAction
 from .errors import FatalError, ConfigError, ConfigErrorScope
 
 
+HELP = """\
+General commands
+  status                                    show service status
+  report                                    report issue
+  logs                                      show service log
+  start                                     start service
+  stop                                      stop service
+  restart                                   restart service
+  down                                      shutdown the environment
+  up                                        bring up the environment
+  help                                      show this help
+  exit                                      exit xud-ctl shell
+
+CLI commands
+  bitcoin-cli                               bitcoind cli
+  litecoin-cli                              litecoind cli
+  lndbtc-lncli                              lnd cli
+  lndltc-lncli                              lnd cli
+  geth                                      geth cli
+  xucli                                     xud cli
+  boltzcli                                  boltz cli
+
+Boltzcli shortcut commands
+  deposit                                   deposit from boltz
+  withdraw                                  withdraw to boltz
+
+Xucli shortcut commands
+  addcurrency <currency>                    add a currency
+  <swap_client> [decimal_places]
+  [token_address]
+  addpair <pair_id|base_currency>           add a trading pair
+  [quote_currency]
+  ban <node_identifier>                     ban a remote node
+  buy <quantity> <pair_id> <price>          place a buy order
+  [order_id]
+  closechannel <currency>                   close any payment channels with a
+  [node_identifier ] [--force]              peer
+  connect <node_uri>                        connect to a remote node
+  create                                    create a new xud instance and set a
+                                            password
+  discovernodes <node_identifier>           discover nodes from a specific peer
+  getbalance [currency]                     get total balance for a given
+                                            currency
+  getinfo                                   get general info from the local xud
+                                            node
+  getnodeinfo <node_identifier>             get general information about a
+                                            known node
+  listcurrencies                            list available currencies
+  listorders [pair_id] [owner]              list orders from the order book
+  [limit]
+  listpairs                                 get order book's available pairs
+  listpeers                                 list connected peers
+  openchannel <currency> <amount>           open a payment channel with a peer
+  [node_identifier] [push_amount]
+  orderbook [pair_id] [precision]           display the order book, with orders
+                                            aggregated per price point
+  removecurrency <currency>                 remove a currency
+  removeorder <order_id> [quantity]         remove an order
+  removepair <pair_id>                      remove a trading pair
+  restore [backup_directory]                restore an xud instance from seed
+  [raiden_database_path]
+  sell <quantity> <pair_id> <price>         place a sell order
+  [order_id]
+  shutdown                                  gracefully shutdown local xud node
+  streamorders [existing]                   stream order added, removed, and
+                                            swapped events (DEMO)
+  tradehistory [limit]                      list completed trades
+  tradinglimits [currency]                  trading limits for a given currency
+  unban <node_identifier>                   unban a previously banned remote
+  [--reconnect]                             node
+  unlock                                    unlock local xud node
+  walletdeposit <currency>                  gets an address to deposit funds to
+                                            xud
+  walletwithdraw [amount] [currency]        withdraws on-chain funds from xud
+  [destination] [fee]
+"""
+
+
 def init_logging():
     fmt = "%(asctime)s.%(msecs)03d %(levelname)s %(process)d --- [%(threadName)s] %(name)s: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
@@ -108,6 +186,8 @@ your issue.""")
                     self.node_manager.cli("boltz", "btc", "withdraw", *args)
                 elif chain == "ltc":
                     self.node_manager.cli("boltz", "ltc", "withdraw", *args)
+            elif arg0 == "help":
+                print(HELP)
             else:
                 self.delegate_cmd_to_xucli(cmd)
         except NodeNotFound as e:

--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -125,11 +125,11 @@ class XudEnv:
         self.node_manager.get_node("xud").cli(cmd, self.shell)
 
     def command_report(self):
-        network_dir = f"{self.config.home_dir}/{self.config.network}"
+        logs_dir = f"{self.config.home_dir}/{self.config.network}/logs"
         print(f"""Please click on https://github.com/ExchangeUnion/xud/issues/\
 new?assignees=kilrau&labels=bug&template=bug-report.md&title=Short%2C+concise+\
-description+of+the+bug, describe your issue, drag and drop the file "xud-docker\
-.log" which is located in "{network_dir}" into your browser window and submit \
+description+of+the+bug, describe your issue, drag and drop the file "{self.config.network}\
+.log" which is located in "{logs_dir}" into your browser window and submit \
 your issue.""")
 
     def handle_command(self, cmd):

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -62,65 +62,290 @@ class Config:
                 v["host"] = self.expand_vars(v["host"])
 
     def parse_command_line_arguments(self):
-        parser = ArgumentParser(argument_default=argparse.SUPPRESS, prog="launcher")
-        parser.add_argument("--branch", "-b")
-        parser.add_argument("--disable-update", action="store_true")
-        parser.add_argument("--simnet-dir")
-        parser.add_argument("--testnet-dir")
-        parser.add_argument("--mainnet-dir")
-        parser.add_argument("--external-ip")
-        parser.add_argument("--xud.preserve-config", action="store_true")
-        parser.add_argument("--lndbtc.preserve-config", action="store_true")
-        parser.add_argument("--lndltc.preserve-config", action="store_true")
+        parser = ArgumentParser(argument_default=argparse.SUPPRESS, prog="xud.sh", usage="bash xud.sh [OPTIONS]")
+        parser.add_argument(
+            "--branch", "-b",
+            metavar="<branch>",
+            help="Git branch name"
+        )
+        parser.add_argument(
+            "--disable-update",
+            action="store_true",
+            help="Skip update checks and enter xud-ctl shell directly"
+        )
+        parser.add_argument(
+            "--simnet-dir",
+            metavar="<dir>",
+            help="Simnet environment folder"
+        )
+        parser.add_argument(
+            "--testnet-dir",
+            metavar="<dir>",
+            help="Testnet environment folder"
+        )
+        parser.add_argument(
+            "--mainnet-dir",
+            metavar="<dir>",
+            help="Mainnet environment folder"
+        )
+        parser.add_argument(
+            "--external-ip",
+            metavar="<ip>",
+            help="Host machine external IP address"
+        )
+        parser.add_argument(
+            "--dev",
+            action="store_true",
+            help="Use local built utils image"
+        )
+        parser.add_argument(
+            "--use-local-images",
+            metavar="<images>",
+            help="Use other local built images"
+        )
 
-        parser.add_argument("--bitcoind.mode")
-        parser.add_argument("--bitcoind.rpc-host")
-        parser.add_argument("--bitcoind.rpc-port", type=int)
-        parser.add_argument("--bitcoind.rpc-user")
-        parser.add_argument("--bitcoind.rpc-password")
-        parser.add_argument("--bitcoind.zmqpubrawblock")
-        parser.add_argument("--bitcoind.zmqpubrawtx")
-        parser.add_argument("--bitcoind.expose-ports")
+        group = parser.add_argument_group("bitcoind")
+        group.add_argument(
+            "--bitcoind.mode",
+            metavar="<mode>",
+            choices=["native", "external", "neutrino", "light"],
+            default="light",
+            help="Bitcoind service mode"
+        )
+        group.add_argument(
+            "--bitcoind.rpc-host",
+            metavar="<hostname>",
+            help="External bitcoind RPC hostname"
+        )
+        group.add_argument(
+            "--bitcoind.rpc-port",
+            type=int,
+            metavar="<port>",
+            help="External bitcoind RPC port"
+        )
+        group.add_argument(
+            "--bitcoind.rpc-user",
+            metavar="<username>",
+            help="External bitcoind RPC username"
+        )
+        group.add_argument(
+            "--bitcoind.rpc-password",
+            metavar="<password>",
+            help="External bitcoind RPC password"
+        )
+        group.add_argument(
+            "--bitcoind.zmqpubrawblock",
+            metavar="<address>",
+            help="External bitcoind ZeroMQ raw blocks publication address"
+        )
+        group.add_argument(
+            "--bitcoind.zmqpubrawtx",
+            metavar="<address>",
+            help="External bitcoind ZeroMQ raw transactions publication address"
+        )
+        group.add_argument(
+            "--bitcoind.expose-ports",
+            metavar="<ports>",
+            help="Expose bitcoind service ports to your host machine"
+        )
 
-        parser.add_argument("--litecoind.mode")
-        parser.add_argument("--litecoind.rpc-host")
-        parser.add_argument("--litecoind.rpc-port", type=int)
-        parser.add_argument("--litecoind.rpc-user")
-        parser.add_argument("--litecoind.rpc-password")
-        parser.add_argument("--litecoind.zmqpubrawblock")
-        parser.add_argument("--litecoind.zmqpubrawtx")
-        parser.add_argument("--litecoind.expose-ports")
+        group = parser.add_argument_group("litecoind")
+        group.add_argument(
+            "--litecoind.mode",
+            metavar="<mode>",
+            choices=["native", "external", "neutrino", "light"],
+            default="light",
+            help="Litecoind service mode"
+        )
+        group.add_argument(
+            "--litecoind.rpc-host",
+            metavar="<hostname>",
+            help="External litecoind RPC hostname"
+        )
+        group.add_argument(
+            "--litecoind.rpc-port",
+            type=int,
+            metavar="<port>",
+            help="External litecoind RPC port"
+        )
+        group.add_argument(
+            "--litecoind.rpc-user",
+            metavar="<username>",
+            help="External litecoind RPC username"
+        )
+        group.add_argument(
+            "--litecoind.rpc-password",
+            metavar="<password>",
+            help="External litecoind RPC password"
+        )
+        group.add_argument(
+            "--litecoind.zmqpubrawblock",
+            metavar="<address>",
+            help="External litecoind ZeroMQ raw blocks publication address"
+        )
+        group.add_argument(
+            "--litecoind.zmqpubrawtx",
+            metavar="<address>",
+            help="External litecoind ZeroMQ raw transactions publication address"
+        )
+        group.add_argument(
+            "--litecoind.expose-ports",
+            metavar="<ports>",
+            help="Expose litecoind service ports to your host machine"
+        )
 
-        parser.add_argument("--geth.mode")
-        parser.add_argument("--geth.rpc-host")
-        parser.add_argument("--geth.rpc-port", type=int)
-        parser.add_argument("--geth.infura-project-id")
-        parser.add_argument("--geth.infura-project-secret")
-        parser.add_argument("--geth.expose-ports")
-        parser.add_argument("--geth.cache", type=int)
+        group = parser.add_argument_group("geth")
+        group.add_argument(
+            "--geth.mode",
+            metavar="<mode>",
+            choices=["native", "external", "infura", "light"],
+            default="light",
+            help="Geth service mode"
+        )
+        group.add_argument(
+            "--geth.rpc-host",
+            metavar="<hostname>",
+            help="External geth RPC hostname"
+        )
+        group.add_argument(
+            "--geth.rpc-port",
+            type=int,
+            metavar="<port>",
+            help="External geth RPC port"
+        )
+        group.add_argument(
+            "--geth.infura-project-id",
+            metavar="<id>",
+            help="Infura geth provider project ID"
+        )
+        group.add_argument(
+            "--geth.infura-project-secret",
+            metavar="<secret>",
+            help="Infura geth provider project secret"
+        )
+        group.add_argument(
+            "--geth.expose-ports",
+            metavar="<ports>",
+            help="Expose geth service ports to your host machine"
+        )
+        group.add_argument(
+            "--geth.cache",
+            type=int,
+            metavar="<size>",
+            help="Geth cache size"
+        )
 
-        parser.add_argument("--lndbtc.expose-ports")
-        parser.add_argument("--lndltc.expose-ports")
-        parser.add_argument("--connext.expose-ports")
-        parser.add_argument("--xud.expose-ports")
+        group = parser.add_argument_group("lndbtc")
+        group.add_argument(
+            "--lndbtc.expose-ports",
+            metavar="<ports>",
+            help="Expose lndbtc service ports to your host machine"
+        )
+        group.add_argument(
+            "--lndbtc.preserve-config",
+            action="store_true",
+            help="Preserve lndbtc lnd.conf file during updates"
+        )
 
-        parser.add_argument("--arby.live-cex")
-        parser.add_argument("--arby.base-asset")
-        parser.add_argument("--arby.quote-asset")
-        parser.add_argument("--arby.test-centralized-baseasset-balance")
-        parser.add_argument("--arby.test-centralized-quoteasset-balance")
-        parser.add_argument("--arby.binance-api-key")
-        parser.add_argument("--arby.binance-api-secret")
-        parser.add_argument("--arby.margin")
-        parser.add_argument("--arby.disabled", nargs='?')
+        group = parser.add_argument_group("lndltc")
+        group.add_argument(
+            "--lndltc.expose-ports",
+            metavar="<ports>",
+            help="Expose lndltc service ports to your host machine"
+        )
+        group.add_argument(
+            "--lndltc.preserve-config",
+            action="store_true",
+            help="Preserve lndltc lnd.conf file during updates"
+        )
 
-        parser.add_argument("--boltz.disabled", nargs='?')
+        group = parser.add_argument_group("connext")
+        group.add_argument(
+            "--connext.expose-ports",
+            metavar="<ports>",
+            help="Expose connext service ports to your host machine"
+        )
 
-        parser.add_argument("--webui.disabled", nargs='?')
-        parser.add_argument("--webui.expose-ports")
+        group = parser.add_argument_group("xud")
+        group.add_argument(
+            "--xud.expose-ports",
+            metavar="<ports>",
+            help="Expose xud service ports to your host machine"
+        )
+        group.add_argument(
+            "--xud.preserve-config",
+            action="store_true",
+            help="Preserve xud xud.conf file during updates"
+        )
 
-        parser.add_argument("--dev", action="store_true")
-        parser.add_argument("--use-local-images")
+        group = parser.add_argument_group("arby")
+        group.add_argument(
+            "--arby.live-cex",
+            metavar="<value>",
+            help="Live CEX"
+        )
+        group.add_argument(
+            "--arby.base-asset",
+            metavar="<asset>",
+            help="Base asset"
+        )
+        group.add_argument(
+            "--arby.quote-asset",
+            metavar="<asset>",
+            help="Quote asset"
+        )
+        group.add_argument(
+            "--arby.test-centralized-baseasset-balance",
+            metavar="<value>",
+            help="Test centralized base asset balance"
+        )
+        group.add_argument(
+            "--arby.test-centralized-quoteasset-balance",
+            metavar="<value>",
+            help="Test centralized quote asset balance"
+        )
+        group.add_argument(
+            "--arby.binance-api-key",
+            metavar="<key>",
+            help="Binance API key"
+        )
+        group.add_argument(
+            "--arby.binance-api-secret",
+            metavar="<secret>",
+            help="Binance API secret"
+        )
+        group.add_argument(
+            "--arby.margin",
+            metavar="<value>",
+            help="Trade margin"
+        )
+        group.add_argument(
+            "--arby.disabled",
+            nargs='?',
+            metavar="true|false",
+            help="Enable/Disable arby service"
+        )
+
+        group = parser.add_argument_group("boltz")
+        group.add_argument(
+            "--boltz.disabled",
+            nargs='?',
+            metavar="true|false",
+            help="Enable/Disable boltz service"
+        )
+
+        group = parser.add_argument_group("webui")
+        group.add_argument(
+            "--webui.disabled",
+            nargs='?',
+            metavar="true|false",
+            help="Enable/Disable webui service"
+        )
+        group.add_argument(
+            "--webui.expose-ports",
+            metavar="<ports>",
+            help="Expose xud service ports to your host machine"
+        )
 
         self.args = parser.parse_args()
         self.logger.info("Parsed command-line arguments: %r", self.args)

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -344,7 +344,7 @@ class Config:
         group.add_argument(
             "--webui.expose-ports",
             metavar="<ports>",
-            help="Expose xud service ports to your host machine"
+            help="Expose webui service ports to your host machine"
         )
 
         self.args = parser.parse_args()

--- a/setup.sh
+++ b/setup.sh
@@ -8,10 +8,100 @@ DOCKER_REGISTRY="https://registry-1.docker.io"
 UTILS_TAG="20.08.07"
 
 
-function parse_branch() {
+function print_help() {
+    cat <<EOF
+xud.sh 20.08.07-dev (revision)
+The launcher script for Exchange Union environment
+
+USAGE:
+    xud.sh [OPTIONS]
+
+OPTIONS:
+    -h, --help                                  Show this help
+    -b, --branch <string>                       Git branch name
+    --disable-update                            Skip update checks and enter xud-ctl shell directly
+    --simnet-dir <path>                         Simnet environment directory path
+    --testnet-dir <path>                        Testnet environment directory path
+    --mainnet-dir <path>                        Mainnet environment directory path
+    --external-ip <ip>                          Host machine Internet IP address
+    --dev                                       Use local built utils image
+    --use-local-images <image>[,<image>]        Use other built images
+
+Bitcoind options:
+    --bitcoind.mode light|neutrino|external|native
+                                                Bitcoind service mode (default: light)
+    --bitcoind.rpc-host <string>                External bitcoind RPC hostname
+    --bitcoind.rpc-port <int>                   External bitcoind RPC port
+    --bitcoind.rpc-user <string>                External bitcoind RPC username
+    --bitcoind.rpc-password <string>            External bitcoind RPC password
+    --bitcoind.zmqpubrawblock <address>         External bitcoind ZeroMQ raw blocks publication address
+    --bitcoind.zmqpubrawtx <address>            External bitcoind ZeroMQ raw transactions publication address
+    --bitcoind.expose-ports <port>[,<port>]     Expose bitcoind service ports to your host machine
+
+Litecoind options:
+    --litecoind.mode light|neutrino|external|native
+                                                Litecoind service mode (default: light)
+    --litecoind.rpc-host <string>               External litecoind RPC hostname
+    --litecoind.rpc-port <int>                  External litecoind RPC port
+    --litecoind.rpc-user <string>               External litecoind RPC username
+    --litecoind.rpc-password <string>           External litecoind RPC password
+    --litecoind.zmqpubrawblock <address>        External litecoind ZeroMQ raw blocks publication address
+    --litecoind.zmqpubrawtx <address>           External litecoind ZeroMQ raw transactions publication address
+    --litecoind.expose-ports <port>[,<port>]    Expose litecoind service ports to your host machine
+
+Geth options:
+    --geth.mode light|infura|external|native    Geth service mode (default: light)
+    --geth.rpc-host <string>                    External geth RPC hostname
+    --geth.rpc-port <int>                       External geth RPC port
+    --geth.infura-project-id <string>           Infura geth provider project ID
+    --geth.infura-project-secret <string>       Infura geth provider project secret
+    --geth.expose-ports <port>[,<port>]         Expose geth service ports to your host machine
+    --geth.cache <int>                          Geth cache size
+
+Lndbtc options:
+    --lndbtc.expose-ports <port>[,<port>]       Expose lndbtc service ports to your host machine
+    --lndbtc.preserve-config                    Preserve lndbtc lnd.conf file during updates
+
+Lndbtc options:
+    --lndltc.expose-ports <port>[,<port>]       Expose lndltc service ports to your host machine
+    --lndltc.preserve-config                    Preserve lndltc lnd.conf file during updates
+
+Connext options:
+    --connext.expose-ports <port>[,<port>]      Expose connext service ports to your host machine
+
+Xud options:
+    --xud.expose-ports <port>[,<port>]          Expose xud service ports to your host machine
+    --xud.preserve-config                       Preserve xud xud.conf file during updates
+
+Arby options:
+    --arby.live-cex true|false                  Production/Demo mode
+    --arby.base-asset <string>                  Base asset symbol
+    --arby.quote-asset <string>                 Quote asset symbol
+    --arby.test-centralized-baseasset-balance   CEX base asset balance for demo mode
+    --arby.test-centralized-quoteasset-balance  CEX quote asset balance for demo mode
+    --arby.binance-api-key <string>             Binance API key
+    --arby.binance-api-secret <string>          Binance API secret
+    --arby.margin <double>                      Trade margin
+    --arby.disabled [true|false]                Enable/Disable arby service
+
+Boltz options:
+    --boltz.disabled [true|false]               Enable/Disable boltz service
+
+Webui options:
+    --webui.disabled [true|false]               Enable/Disable webui service
+    --webui.expose-ports <port>[,<port>]        Expose webui service ports to your host machine
+EOF
+}
+
+
+function parse_opts() {
     local OPTION VALUE
     while [[ $# -gt 0 ]]; do
         case $1 in
+        "-h" | "--help" )
+            print_help
+            exit 1
+            ;;
         "-b" | "--branch")
             if [[ $1 =~ = ]]; then
                 VALUE=$(echo "$1" | cut -d'=' -f2)
@@ -37,28 +127,32 @@ function parse_branch() {
 }
 
 function choose_network() {
-    echo "1) Simnet"
-    echo "2) Testnet"
-    echo "3) Mainnet"
-    read -p "Please choose the network: " -r
-    shopt -s nocasematch
-    REPLY=$(echo "$REPLY" | awk '{$1=$1;print}') # trim whitespaces
-    case $REPLY in
-    1 | simnet)
-        NETWORK=simnet
-        ;;
-    2 | testnet)
-        NETWORK=testnet
-        ;;
-    3 | mainnet)
-        NETWORK=mainnet
-        ;;
-    *)
-        echo >&2 "❌ Invalid network: $REPLY"
-        exit 1
-        ;;
-    esac
-    shopt -u nocasematch
+    while true; do
+        echo "1) Simnet"
+        echo "2) Testnet"
+        echo "3) Mainnet"
+        read -p "Please choose the network: " -r
+        shopt -s nocasematch
+        REPLY=$(echo "$REPLY" | awk '{$1=$1;print}') # trim whitespaces
+        case $REPLY in
+        1 | simnet)
+            NETWORK=simnet
+            break
+            ;;
+        2 | testnet)
+            NETWORK=testnet
+            break
+            ;;
+        3 | mainnet)
+            NETWORK=mainnet
+            break
+            ;;
+        *)
+            continue
+            ;;
+        esac
+        shopt -u nocasematch
+    done
 }
 
 function get_token() {
@@ -261,7 +355,7 @@ function get_utils_name() {
 
 LOG_TIMESTAMP="$(date +%F-%H-%M-%S)"
 
-parse_branch "$@"
+parse_opts "$@"
 
 choose_network
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,7 @@ OPTIONS:
     --use-local-images <image>[,<image>]        Use other built images
 
 Bitcoind options:
-    --bitcoind.mode light|neutrino|external|native
+    --bitcoind.mode [light|neutrino|external|native]
                                                 Bitcoind service mode (default: light)
     --bitcoind.rpc-host <string>                External bitcoind RPC hostname
     --bitcoind.rpc-port <int>                   External bitcoind RPC port
@@ -39,7 +39,7 @@ Bitcoind options:
     --bitcoind.expose-ports <port>[,<port>]     Expose bitcoind service ports to your host machine
 
 Litecoind options:
-    --litecoind.mode light|neutrino|external|native
+    --litecoind.mode [light|neutrino|external|native]
                                                 Litecoind service mode (default: light)
     --litecoind.rpc-host <string>               External litecoind RPC hostname
     --litecoind.rpc-port <int>                  External litecoind RPC port
@@ -50,7 +50,7 @@ Litecoind options:
     --litecoind.expose-ports <port>[,<port>]    Expose litecoind service ports to your host machine
 
 Geth options:
-    --geth.mode light|infura|external|native    Geth service mode (default: light)
+    --geth.mode [light|infura|external|native]  Geth service mode (default: light)
     --geth.rpc-host <string>                    External geth RPC hostname
     --geth.rpc-port <int>                       External geth RPC port
     --geth.infura-project-id <string>           Infura geth provider project ID
@@ -74,7 +74,7 @@ Xud options:
     --xud.preserve-config                       Preserve xud xud.conf file during updates
 
 Arby options:
-    --arby.live-cex true|false                  Production/Demo mode
+    --arby.live-cex [true|false]                Production/Demo mode (default: false)
     --arby.base-asset <string>                  Base asset symbol
     --arby.quote-asset <string>                 Quote asset symbol
     --arby.test-centralized-baseasset-balance   CEX base asset balance for demo mode


### PR DESCRIPTION
This PR refines `--help` option ouptut and adds `help` command to xud-ctl shell.

Resolves #369 

### How to test?

```
bash xud.sh -b big-help --help
```

```
bash xud.sh -b big-help
# In xud-ctl shell
network > help
```