### PR TITLE
fix: xud image hosts file

### DIFF
--- a/images/xud/entrypoint.sh
+++ b/images/xud/entrypoint.sh
@@ -55,15 +55,15 @@ echo "[entrypoint] Onion address for xud is $XUD_ADDRESS"
 
 echo '[entrypoint] Detecting localnet IP for lndbtc...'
 LNDBTC_IP=$(getent hosts lndbtc || echo '' | awk '{ print $1 }')
-echo "[entrypoint] $LNDBTC_IP lndbtc" >> /etc/hosts
+echo "$LNDBTC_IP lndbtc" >> /etc/hosts
 
 echo '[entrypoint] Detecting localnet IP for lndltc...'
 LNDLTC_IP=$(getent hosts lndltc || echo '' | awk '{ print $1 }')
-echo "[entrypoint] $LNDLTC_IP lndltc" >> /etc/hosts
+echo "$LNDLTC_IP lndltc" >> /etc/hosts
 
 echo '[entrypoint] Detecting localnet IP for connext...'
 CONNEXT_IP=$(getent hosts connext || echo '' | awk '{ print $1 }')
-echo "[entrypoint] $CONNEXT_IP connext" >> /etc/hosts
+echo "$CONNEXT_IP connext" >> /etc/hosts
 
 
 while [[ ! -e /root/.lndbtc/tls.cert ]]; do


### PR DESCRIPTION
This PR remove "[entrypint]" from xud image /etc/hosts file.

### How to test?

```bash
bash xud.sh
# select simnet
docker exec simnet_xud_1 cat /etc/hosts

bash xud.sh -b fix-xud-hosts
# select simnet
docker exec simnet_xud_1 cat /etc/hosts
```