### PR TITLE
chore: update boltz to v1.1.1 on mainnet

### DIFF
--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -470,7 +470,7 @@ nodes_config = {
         },
         "boltz": {
             "name": "boltz",
-            "image": "exchangeunion/boltz:1.1.0",
+            "image": "exchangeunion/boltz:1.1.1",
             "volumes": [
                 {
                     "host": "$data_dir/boltz",


### PR DESCRIPTION
Updates boltz-lnd on mainnet to [`v1.1.1`](https://github.com/BoltzExchange/boltz-lnd/releases/tag/v1.1.1) which fixes https://github.com/BoltzExchange/boltz-lnd/issues/19