### PR TITLE
feat: add xud-docker api

### DIFF
--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.15.2-alpine3.12 as builder
+ADD .src github.com/ExchangeUnion/xud-docker-api-poc
+WORKDIR github.com/ExchangeUnion/xud-docker-api-poc
+RUN go build
+
+FROM alpine:3.12
+COPY --from=builder /go/github.com/ExchangeUnion/xud-docker-api-poc/xud-docker-api-poc /usr/local/bin/proxy
+ADD entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/proxy/entrypoint.sh
+++ b/images/proxy/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+while [ ! -e /root/.xud/tls.cert ]; do
+    echo "[entrypoint] Waiting for xud tls.cert to be created..."
+    sleep 3
+done
+
+#shellcheck disable=2068
+exec proxy $@

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -1,0 +1,1 @@
+REPO_URL = "https://github.com/ExchangeUnion/xud-docker-api-poc"

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -349,6 +349,19 @@ class Config:
             help="Expose webui service ports to your host machine"
         )
 
+        group = parser.add_argument_group("proxy")
+        group.add_argument(
+            "--proxy.disabled",
+            nargs='?',
+            metavar="true|false",
+            help="Enable/Disable proxy service"
+        )
+        group.add_argument(
+            "--proxy.expose-ports",
+            metavar="<ports>",
+            help="Expose proxy service ports to your host machine"
+        )
+
         self.args = parser.parse_args()
         self.logger.info("Parsed command-line arguments: %r", self.args)
 
@@ -771,7 +784,13 @@ class Config:
         """Update proxy related configurations from parsed TOML webui section
         :param parsed: Parsed proxy TOML section
         """
-        pass
+        node = self.nodes["proxy"]
+        self.update_disabled(node, parsed, "proxy.disabled")
+        self.update_ports(node, parsed, mapping={
+            "8889": "8889:8080",
+            "18889": "18889:8080",
+            "28889": "28889:8080",
+        })
 
     def parse_network_config(self):
         network = self.network
@@ -837,10 +856,6 @@ class Config:
         if hasattr(self.args, "lndltc.preserve_config"):
             if "lndltc" in self.nodes:
                 self.nodes["lndltc"]["preserve_config"] = True
-
-        if hasattr(self.args, "api"):
-            if "proxy" in self.nodes:
-                self.nodes["proxy"]["disabled"] = False
 
     def expand_vars(self, value):
         if value is None:

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -103,6 +103,11 @@ class Config:
             metavar="<images>",
             help="Use other local built images"
         )
+        parser.add_argument(
+            "--api",
+            action="store_true",
+            help="Expose xud-docker API (REST + WebSocket)"
+        )
 
         group = parser.add_argument_group("bitcoind")
         group.add_argument(
@@ -762,6 +767,12 @@ class Config:
             "28888": "28888:8080",
         })
 
+    def update_proxy(self, parsed):
+        """Update proxy related configurations from parsed TOML webui section
+        :param parsed: Parsed proxy TOML section
+        """
+        pass
+
     def parse_network_config(self):
         network = self.network
 
@@ -826,6 +837,10 @@ class Config:
         if hasattr(self.args, "lndltc.preserve_config"):
             if "lndltc" in self.nodes:
                 self.nodes["lndltc"]["preserve_config"] = True
+
+        if hasattr(self.args, "api"):
+            if "proxy" in self.nodes:
+                self.nodes["proxy"]["disabled"] = False
 
     def expand_vars(self, value):
         if value is None:

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -134,3 +134,7 @@
 [webui]
 #disabled = false
 #expose-ports = ["8888:8080"]
+
+[proxy]
+#disabled = false
+#expose-ports = ["8889"]

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -47,3 +47,7 @@
 [webui]
 #disabled = false
 #expose-ports = ["28888:8080"]
+
+[proxy]
+#disabled = false
+#expose-ports = ["28889"]

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -133,6 +133,21 @@ nodes_config = {
             "use_local_image": False,
             "disabled": True,
         },
+        "proxy": {
+            "name": "proxy",
+            "image": "exchangeunion/proxy:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [PortPublish("8080:8080")],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+            "disabled": True,
+        },
         "xud": {
             "name": "xud",
             "image": "exchangeunion/xud:latest",
@@ -320,6 +335,21 @@ nodes_config = {
             "use_local_image": False,
             "disabled": True,
         },
+        "proxy": {
+            "name": "proxy",
+            "image": "exchangeunion/proxy:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [PortPublish("8081:8080")],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+            "disabled": True,
+        },
         "xud": {
             "name": "xud",
             "image": "exchangeunion/xud:latest",
@@ -501,6 +531,21 @@ nodes_config = {
                 }
             ],
             "ports": [PortPublish("8888:8080")],
+            "mode": "native",
+            "preserve_config": False,
+            "use_local_image": False,
+            "disabled": True,
+        },
+        "proxy": {
+            "name": "proxy",
+            "image": "exchangeunion/proxy:latest",
+            "volumes": [
+                {
+                    "host": "$data_dir/xud",
+                    "container": "/root/.xud",
+                }
+            ],
+            "ports": [PortPublish("8082:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -142,7 +142,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [PortPublish("8080:8080")],
+            "ports": [PortPublish("28889:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -344,7 +344,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [PortPublish("8081:8080")],
+            "ports": [PortPublish("18889:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -545,7 +545,7 @@ nodes_config = {
                     "container": "/root/.xud",
                 }
             ],
-            "ports": [PortPublish("8082:8080")],
+            "ports": [PortPublish("8889:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -137,3 +137,7 @@
 [webui]
 #disabled = false
 #expose-ports = ["18888:8080"]
+
+[proxy]
+#disabled = false
+#expose-ports = ["18889"]

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -21,6 +21,7 @@ from .image import Image, ImageManager
 from .lnd import Lndbtc, Lndltc
 from .webui import Webui
 from .xud import Xud, XudApiError
+from .proxy import Proxy
 from .DockerTemplate import DockerTemplate
 from ..config import Config
 from ..errors import FatalError

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -329,7 +329,7 @@ class NodeManager:
         self.get_node(name).cli(" ".join(args), self.shell)
 
     def _get_status_nodes(self):
-        optional_nodes = ["arby", "boltz", "webui"]
+        optional_nodes = ["arby", "boltz", "webui", "proxy"]
         result = {}
         for node in self.nodes.values():
             if node.name in optional_nodes:

--- a/images/utils/launcher/node/proxy.py
+++ b/images/utils/launcher/node/proxy.py
@@ -1,0 +1,22 @@
+from .base import Node
+
+
+class Proxy(Node):
+    def __init__(self, name, ctx):
+        super().__init__(name, ctx)
+
+        command = [
+            "--xud.rpchost=xud",
+            "--xud.rpccert=/root/.xud/tls.cert",
+        ]
+        if self.network == "simnet":
+            command.append("--xud.rpcport=28886")
+        elif self.network == "testnet":
+            command.append("--xud.rpcport=18886")
+        elif self.network == "mainnet":
+            command.append("--xud.rpcport=8886")
+
+        self.container_spec.command.extend(command)
+
+    def status(self):
+        return "Ready"

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,7 @@ OPTIONS:
     --external-ip <ip>                          Host machine Internet IP address
     --dev                                       Use local built utils image
     --use-local-images <image>[,<image>]        Use other built images
+    --api                                       Expose xud-docker API (REST + WebSocket)
 
 Bitcoind options:
     --bitcoind.mode [light|neutrino|external|native]

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,6 @@ OPTIONS:
     --external-ip <ip>                          Host machine Internet IP address
     --dev                                       Use local built utils image
     --use-local-images <image>[,<image>]        Use other built images
-    --api                                       Expose xud-docker API (REST + WebSocket)
 
 Bitcoind options:
     --bitcoind.mode [light|neutrino|external|native]
@@ -91,6 +90,10 @@ Boltz options:
 Webui options:
     --webui.disabled [true|false]               Enable/Disable webui service
     --webui.expose-ports <port>[,<port>]        Expose webui service ports to your host machine
+
+Proxy options:
+    --proxy.disabled [true|false]               Enable/Disable proxy service
+    --proxy.expose-ports <port>[,<port>]        Expose proxy service ports to your host machine
 EOF
 }
 


### PR DESCRIPTION
This PR adds `--api` optinon for xud-docker-api poc #725

### How to test?

```bash
bash xud.sh -b api --proxy.disabled=false
# select simnet
curl localhost:8080/api/v1/xud/getinfo
```

The default API ports for different networks
1. simnet: 8080 (changed to 28889)
2. testnet: 8081 (changed to 18889)
3. mainnet: 8082 (changed to 8889)

