### PR TITLE
feat: add status api

### DIFF
--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.15.2-alpine3.12 as builder
-ADD .src github.com/ExchangeUnion/xud-docker-api-poc
 WORKDIR github.com/ExchangeUnion/xud-docker-api-poc
-RUN go build
+COPY .src/go.mod .
+COPY .src/go.sum .
+RUN go mod download
+ADD .src .
+RUN go build ./cmd/proxy
 
 FROM alpine:3.12
-COPY --from=builder /go/github.com/ExchangeUnion/xud-docker-api-poc/xud-docker-api-poc /usr/local/bin/proxy
+COPY --from=builder /go/github.com/ExchangeUnion/xud-docker-api-poc/proxy /usr/local/bin/proxy
 ADD entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12 as builder
+FROM golang:1.15-alpine3.12 as builder
 WORKDIR github.com/ExchangeUnion/xud-docker-api-poc
 COPY .src/go.mod .
 COPY .src/go.sum .

--- a/images/proxy/entrypoint.sh
+++ b/images/proxy/entrypoint.sh
@@ -5,5 +5,15 @@ while [ ! -e /root/.xud/tls.cert ]; do
     sleep 3
 done
 
+while [ ! -e /root/.lndbtc/tls.cert ]; do
+    echo "[entrypoint] Waiting for lndbtc tls.cert to be created..."
+    sleep 3
+done
+
+while [ ! -e /root/.lndltc/tls.cert ]; do
+    echo "[entrypoint] Waiting for lndltc tls.cert to be created..."
+    sleep 3
+done
+
 #shellcheck disable=2068
 exec proxy $@

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -3,7 +3,7 @@ from tools.core import src
 
 class SourceManager(src.SourceManager):
     def __init__(self):
-        super().__init__("https://github.com/ExchangeUnion/xud-docker-api-poc")
+        super().__init__("https://github.com/ExchangeUnion/xud-docker-api")
 
     def get_ref(self, version):
         if version == "latest":

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -8,6 +8,6 @@ class SourceManager(src.SourceManager):
     def get_ref(self, version):
         if version == "latest":
             # change "master" to a another xud branch for testing
-            return "master"
+            return "add-proxy"
         else:
             return "v" + version

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -1,1 +1,13 @@
-REPO_URL = "https://github.com/ExchangeUnion/xud-docker-api-poc"
+from tools.core import src
+
+
+class SourceManager(src.SourceManager):
+    def __init__(self):
+        super().__init__("https://github.com/ExchangeUnion/xud-docker-api-poc")
+
+    def get_ref(self, version):
+        if version == "latest":
+            # change "master" to a another xud branch for testing
+            return "status"
+        else:
+            return "v" + version

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -8,6 +8,6 @@ class SourceManager(src.SourceManager):
     def get_ref(self, version):
         if version == "latest":
             # change "master" to a another xud branch for testing
-            return "status"
+            return "master"
         else:
             return "v" + version

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -8,6 +8,6 @@ class SourceManager(src.SourceManager):
     def get_ref(self, version):
         if version == "latest":
             # change "master" to a another xud branch for testing
-            return "add-proxy"
+            return "master"
         else:
             return "v" + version

--- a/images/utils/Dockerfile
+++ b/images/utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.2-alpine3.11
+FROM python:3.8-alpine3.12
 RUN pip install toml docker demjson
 ADD . /usr/local/src/utils
 WORKDIR /usr/local/src/utils

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -929,6 +929,8 @@ class Config:
                 value = value.replace(f"${self.network}_dir", self.network_dir)
             if "$data_dir" in value:
                 value = value.replace("$data_dir", self.network_dir + "/data")
+            if "$logs_dir" in value:
+                value = value.replace("$logs_dir", self.logs_dir)
         return value
 
     @property

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -153,9 +153,21 @@ nodes_config = {
             "image": "exchangeunion/proxy:latest",
             "volumes": [
                 {
+                    "host": "/var/run/docker.sock",
+                    "container": "/var/run/docker.sock",
+                },
+                {
                     "host": "$data_dir/xud",
                     "container": "/root/.xud",
-                }
+                },
+                {
+                    "host": "$data_dir/lndbtc",
+                    "container": "/root/.lndbtc",
+                },
+                {
+                    "host": "$data_dir/lndltc",
+                    "container": "/root/.lndltc",
+                },
             ],
             "ports": [PortPublish("28889:8080")],
             "mode": "native",
@@ -355,9 +367,21 @@ nodes_config = {
             "image": "exchangeunion/proxy:latest",
             "volumes": [
                 {
+                    "host": "/var/run/docker.sock",
+                    "container": "/var/run/docker.sock",
+                },
+                {
                     "host": "$data_dir/xud",
                     "container": "/root/.xud",
-                }
+                },
+                {
+                    "host": "$data_dir/lndbtc",
+                    "container": "/root/.lndbtc",
+                },
+                {
+                    "host": "$data_dir/lndltc",
+                    "container": "/root/.lndltc",
+                },
             ],
             "ports": [PortPublish("18889:8080")],
             "mode": "native",
@@ -556,9 +580,21 @@ nodes_config = {
             "image": "exchangeunion/proxy:latest",
             "volumes": [
                 {
+                    "host": "/var/run/docker.sock",
+                    "container": "/var/run/docker.sock",
+                },
+                {
                     "host": "$data_dir/xud",
                     "container": "/root/.xud",
-                }
+                },
+                {
+                    "host": "$data_dir/lndbtc",
+                    "container": "/root/.lndbtc",
+                },
+                {
+                    "host": "$data_dir/lndltc",
+                    "container": "/root/.lndltc",
+                },
             ],
             "ports": [PortPublish("8889:8080")],
             "mode": "native",

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -6,7 +6,7 @@ class PortPublish:
     def __init__(self, value):
         p1 = re.compile(r"^(\d+)$")  # 8080
         p2 = re.compile(r"^(\d+):(\d+)$")  # 80:8080
-        p3 = re.compile(r"^(\d+):(\d+):(\d+)$")  # 127.0.0.1:80:8080
+        p3 = re.compile(r"^(.+):(\d+):(\d+)$")  # 127.0.0.1:80:8080
 
         protocol = "tcp"
         if "/" in value:
@@ -35,6 +35,8 @@ class PortPublish:
                     host = m.group(1)
                     host_port = int(m.group(2))
                     port = int(m.group(3))
+                else:
+                    raise FatalError("Invalid port publish: {}".format(value))
 
         self.protocol = protocol
         self.host = host
@@ -157,7 +159,7 @@ nodes_config = {
                     "container": "/var/run/docker.sock",
                 },
                 {
-                    "host": "$data_dir/logs/config.sh",
+                    "host": "$logs_dir/config.sh",
                     "container": "/root/config.sh",
                 },
                 {
@@ -173,7 +175,7 @@ nodes_config = {
                     "container": "/root/.lndltc",
                 },
             ],
-            "ports": [PortPublish("28889:8080")],
+            "ports": [PortPublish("127.0.0.1:28889:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -375,7 +377,7 @@ nodes_config = {
                     "container": "/var/run/docker.sock",
                 },
                 {
-                    "host": "$data_dir/logs/config.sh",
+                    "host": "$logs_dir/config.sh",
                     "container": "/root/config.sh",
                 },
                 {
@@ -390,8 +392,9 @@ nodes_config = {
                     "host": "$data_dir/lndltc",
                     "container": "/root/.lndltc",
                 },
+
             ],
-            "ports": [PortPublish("18889:8080")],
+            "ports": [PortPublish("127.0.0.1:18889:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
@@ -592,7 +595,7 @@ nodes_config = {
                     "container": "/var/run/docker.sock",
                 },
                 {
-                    "host": "$data_dir/logs/config.sh",
+                    "host": "$logs_dir/config.sh",
                     "container": "/root/config.sh",
                 },
                 {
@@ -608,7 +611,7 @@ nodes_config = {
                     "container": "/root/.lndltc",
                 },
             ],
-            "ports": [PortPublish("8889:8080")],
+            "ports": [PortPublish("127.0.0.1:8889:8080")],
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -157,6 +157,10 @@ nodes_config = {
                     "container": "/var/run/docker.sock",
                 },
                 {
+                    "host": "$data_dir/logs/config.sh",
+                    "container": "/root/config.sh",
+                },
+                {
                     "host": "$data_dir/xud",
                     "container": "/root/.xud",
                 },
@@ -371,6 +375,10 @@ nodes_config = {
                     "container": "/var/run/docker.sock",
                 },
                 {
+                    "host": "$data_dir/logs/config.sh",
+                    "container": "/root/config.sh",
+                },
+                {
                     "host": "$data_dir/xud",
                     "container": "/root/.xud",
                 },
@@ -582,6 +590,10 @@ nodes_config = {
                 {
                     "host": "/var/run/docker.sock",
                     "container": "/var/run/docker.sock",
+                },
+                {
+                    "host": "$data_dir/logs/config.sh",
+                    "container": "/root/config.sh",
                 },
                 {
                     "host": "$data_dir/xud",

--- a/images/utils/launcher/node/image.py
+++ b/images/utils/launcher/node/image.py
@@ -344,7 +344,7 @@ class ImageManager:
             self.logger.info("(%s) Checking for updates: %s", i.name, i.status)
 
         try:
-            parallel_execute(images, lambda i: wrapper(i), 20, print_failed, try_again)
+            parallel_execute(images, lambda i: wrapper(i), 30, print_failed, try_again)
         except ParallelExecutionError as e:
             for image, error in e.failed:
                 error_msg = str(error)

--- a/images/utils/launcher/node/proxy.py
+++ b/images/utils/launcher/node/proxy.py
@@ -5,18 +5,5 @@ class Proxy(Node):
     def __init__(self, name, ctx):
         super().__init__(name, ctx)
 
-        command = [
-            "--xud.rpchost=xud",
-            "--xud.rpccert=/root/.xud/tls.cert",
-        ]
-        if self.network == "simnet":
-            command.append("--xud.rpcport=28886")
-        elif self.network == "testnet":
-            command.append("--xud.rpcport=18886")
-        elif self.network == "mainnet":
-            command.append("--xud.rpcport=8886")
-
-        self.container_spec.command.extend(command)
-
     def status(self):
         return "Ready"

--- a/xud.sh
+++ b/xud.sh
@@ -42,11 +42,11 @@ else
     EXIT_CODE="$?"
     case "$EXIT_CODE" in
     6)
-        echo >&2 "Couldn't resolve host: raw.githubusercontent.com (please check your internet connection and https://githubstatus.com)"
+        echo >&2 "Couldn't resolve host: raw.githubusercontent.com (please check your Internet connection and https://githubstatus.com)"
         exit 1
         ;;
     7)
-        echo >&2 "Failed to connect to host: raw.githubusercontent.com (please check your internet connection and https://githubstatus.com)"
+        echo >&2 "Failed to connect to host: raw.githubusercontent.com (please check your Internet connection and https://githubstatus.com)"
         exit 1
         ;;
     *)

--- a/xud.sh
+++ b/xud.sh
@@ -32,12 +32,17 @@ parse_arguments "$@"
 
 URL="https://raw.githubusercontent.com/ExchangeUnion/xud-docker/$BRANCH/setup.sh"
 
+if ! command -v curl >/dev/null; then
+    echo >&2 "Command \"curl\" not found"
+    exit 1
+fi
+
 if SCRIPT=$(curl -s "$URL"); then
     if [[ "$SCRIPT" == "404: Not Found" ]]; then
         echo >&2 "Xud-docker branch \"$BRANCH\" does not exist"
         exit 1
     fi
-    bash -c "$SCRIPT"
+    bash -c "$SCRIPT" -- "$@"
 else
     EXIT_CODE="$?"
     case "$EXIT_CODE" in


### PR DESCRIPTION
This PR updates proxy image with `status` branch of [xud-docker-api-poc](https://github.com/exchangeunion/xud-docker-api-poc) which add status API for each services.

### How to test?

```
bash xud.sh -b status-api --proxy.disabled=false
# select testnet
curl -s localhost:18889/api/v1/status
```

You should got a JSON response like

```json
{"arby":"Container missing","bitcoind":"Ready (light mode)","boltz":"Ready","connext":"Ready","geth":"Ready (light mode)","litecoind":"Ready (light mode)","lndbtc":"Ready","lndltc":"Ready","webui":"Container missing","xud":"Waiting for channels"}
```