### PR TITLE
feat: change arby config

### DIFF
--- a/images/arby/src.py
+++ b/images/arby/src.py
@@ -13,7 +13,6 @@ class SourceManager(src.SourceManager):
 
     def get_ref(self, version):
         if version == "latest":
-            # change "master" to a another xud branch for testing
-            return "feat/config-defaults"
+            return "master"
         else:
             return "v" + version

--- a/images/arby/src.py
+++ b/images/arby/src.py
@@ -1,1 +1,19 @@
-REPO_URL = "https://github.com/ExchangeUnion/market-maker-tools"
+from tools.core import src
+
+
+class SourceManager(src.SourceManager):
+    def __init__(self):
+        super().__init__("https://github.com/ExchangeUnion/market-maker-tools")
+
+    def get_build_args(self, version):
+        revision = self.get_revision(self.src_dir)
+        return {
+            "GIT_REVISION": revision[:8]
+        }
+
+    def get_ref(self, version):
+        if version == "latest":
+            # change "master" to a another xud branch for testing
+            return "feat/config-defaults"
+        else:
+            return "v" + version

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -287,14 +287,14 @@ class Config:
             help="Live CEX"
         )
         group.add_argument(
-            "--arby.opendex-base-asset",
+            "--arby.base-asset",
             metavar="<asset>",
-            help="OpenDEX base asset"
+            help="Base asset"
         )
         group.add_argument(
-            "--arby.opendex-quote-asset",
+            "--arby.quote-asset",
             metavar="<asset>",
-            help="OpenDEX quote asset"
+            help="Quote asset"
         )
         group.add_argument(
             "--arby.cex-base-asset",
@@ -712,25 +712,25 @@ class Config:
             if value:
                 node["test-centralized-quoteasset-balance"] = value
 
-        if "opendex-base-asset" in parsed:
-            if parsed["opendex-base-asset"]:
-                value = parsed["opendex-base-asset"]
-                node["opendex-base-asset"] = value
-        opt = "arby.opendex_base_asset"
+        if "base-asset" in parsed:
+            if parsed["base-asset"]:
+                value = parsed["base-asset"]
+                node["base-asset"] = value
+        opt = "arby.base_asset"
         if hasattr(self.args, opt):
             value = getattr(self.args, opt)
             if value:
-                node["opendex-base-asset"] = value
+                node["base-asset"] = value
 
-        if "opendex-quote-asset" in parsed:
-            if parsed["opendex-quote-asset"]:
-                value = parsed["opendex-quote-asset"]
-                node["opendex-quote-asset"] = value
-        opt = "arby.opendex_quote_asset"
+        if "quote-asset" in parsed:
+            if parsed["quote-asset"]:
+                value = parsed["quote-asset"]
+                node["quote-asset"] = value
+        opt = "arby.quote_asset"
         if hasattr(self.args, opt):
             value = getattr(self.args, opt)
             if value:
-                node["opendex-quote-asset"] = value
+                node["quote-asset"] = value
 
         if "cex-base-asset" in parsed:
             if parsed["cex-base-asset"]:

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -125,7 +125,7 @@
 #base-asset = "BTC"
 #quote-asset = "USDT"
 #cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
-#cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-quote-asset = "" # optional - only needs to be specified if centralized exchange quote asset is different from quote-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #cex = "binance"

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -124,7 +124,7 @@
 #live-cex="false"
 #base-asset = "BTC"
 #quote-asset = "USDT"
-#cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-base-asset = "" # optional - only needs to be specified if centralized exchange base asset is different from base-asset
 #cex-quote-asset = "" # optional - only needs to be specified if centralized exchange quote asset is different from quote-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"

--- a/images/utils/launcher/config/mainnet.conf
+++ b/images/utils/launcher/config/mainnet.conf
@@ -122,10 +122,10 @@
 
 [arby]
 #live-cex="false"
-#opendex-base-asset = "BTC"
-#opendex-quote-asset = "USDT"
-#cex-base-asset = "BTC"
-#cex-quote-asset = "USDT"
+#base-asset = "BTC"
+#quote-asset = "USDT"
+#cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #cex = "binance"

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -38,7 +38,7 @@
 #base-asset = "BTC"
 #quote-asset = "USDT"
 #cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
-#cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-quote-asset = "" # optional - only needs to be specified if centralized exchange quote asset is different from quote-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #cex = "binance"

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -37,7 +37,7 @@
 #live-cex="false"
 #base-asset = "BTC"
 #quote-asset = "USDT"
-#cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-base-asset = "" # optional - only needs to be specified if centralized exchange base asset is different from base-asset
 #cex-quote-asset = "" # optional - only needs to be specified if centralized exchange quote asset is different from quote-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"

--- a/images/utils/launcher/config/simnet.conf
+++ b/images/utils/launcher/config/simnet.conf
@@ -35,10 +35,10 @@
 
 [arby]
 #live-cex="false"
-#opendex-base-asset = "BTC"
-#opendex-quote-asset = "USDT"
-#cex-base-asset = "BTC"
-#cex-quote-asset = "USDT"
+#base-asset = "BTC"
+#quote-asset = "USDT"
+#cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #cex = "binance"

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -481,7 +481,7 @@ nodes_config = {
         },
         "arby": {
             "name": "arby",
-            "image": "exchangeunion/arby:1.2.2",
+            "image": "exchangeunion/arby:1.2.3",
             "volumes": [
                 {
                     "host": "$data_dir/arby",

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -125,7 +125,7 @@
 #base-asset = "ETH"
 #quote-asset = "BTC"
 #cex-base-asset = "" # optional - only needs to be specified if centralized exchange base asset is different from base-asset
-#cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-quote-asset = "" # optional - only needs to be specified if centralized exchange quote asset is different from quote-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #cex = "binance"

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -124,7 +124,7 @@
 #live-cex="false"
 #base-asset = "ETH"
 #quote-asset = "BTC"
-#cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-base-asset = "" # optional - only needs to be specified if centralized exchange base asset is different from base-asset
 #cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"

--- a/images/utils/launcher/config/testnet.conf
+++ b/images/utils/launcher/config/testnet.conf
@@ -122,10 +122,10 @@
 
 [arby]
 #live-cex="false"
-#opendex-base-asset = "ETH"
-#opendex-quote-asset = "BTC"
-#cex-base-asset = "ETH"
-#cex-quote-asset = "BTC"
+#base-asset = "ETH"
+#quote-asset = "BTC"
+#cex-base-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
+#cex-quote-asset = "" # optional - only needs to be specified when centralized exchange base asset is different from base-asset
 #test-centralized-baseasset-balance = "123"
 #test-centralized-quoteasset-balance = "321"
 #cex = "binance"

--- a/images/utils/launcher/node/arby.py
+++ b/images/utils/launcher/node/arby.py
@@ -27,10 +27,10 @@ class Arby(Node):
             if "test-centralized-baseasset-balance" in self.node_config else "123"
         test_centralized_quoteasset_balance = self.node_config["test-centralized-quoteasset-balance"] \
             if "test-centralized-baseasset-balance" in self.node_config else "321"
-        opendex_base_asset = self.node_config["opendex-base-asset"] \
-            if "opendex-base-asset" in self.node_config else ""
-        opendex_quote_asset = self.node_config["opendex-quote-asset"] \
-            if "opendex-quote-asset" in self.node_config else ""
+        base_asset = self.node_config["base-asset"] \
+            if "base-asset" in self.node_config else ""
+        quote_asset = self.node_config["quote-asset"] \
+            if "quote-asset" in self.node_config else ""
         cex_base_asset = self.node_config["cex-base-asset"] \
             if "cex-base-asset" in self.node_config else ""
         cex_quote_asset = self.node_config["cex-quote-asset"] \
@@ -49,8 +49,8 @@ class Arby(Node):
             "DATA_DIR=/root/.arby",
             "OPENDEX_CERT_PATH=/root/.xud/tls.cert",
             "OPENDEX_RPC_HOST=xud",
-            f"OPENDEX_BASEASSET={opendex_base_asset}",
-            f"OPENDEX_QUOTEASSET={opendex_quote_asset}",
+            f"BASEASSET={base_asset}",
+            f"QUOTEASSET={quote_asset}",
             f"CEX_BASEASSET={cex_base_asset}",
             f"CEX_QUOTEASSET={cex_quote_asset}",
             f"OPENDEX_RPC_PORT={rpc_port}",

--- a/setup.sh
+++ b/setup.sh
@@ -75,8 +75,8 @@ Xud options:
 
 Arby options:
     --arby.live-cex [true|false]                Production/Demo mode (default: false)
-    --arby.opendex-base-asset <string>          OpenDEX base asset symbol
-    --arby.opendex-quote-asset <string>         OpenDEX quote asset symbol
+    --arby.base-asset <string>                  Base asset symbol
+    --arby.quote-asset <string>                 Quote asset symbol
     --arby.cex-base-asset <string>              Centralized exchange base asset symbol
     --arby.cex-quote-asset <string>             Centralized exchange quote asset symbol
     --arby.test-centralized-baseasset-balance   CEX base asset balance for demo mode


### PR DESCRIPTION
This PR renames arby's `opendex-baseasset` and `opendex-quoteasset` back to `baseasset` and `quoteasset`.

Additionally, if `cex-baseasset` or `cex-quoteasset` is not specified the value of `baseasset` and `quoteasset` will be used by default.