### PR TITLE
feat: dump config

### DIFF
--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -98,7 +98,7 @@ Boltzcli shortcut commands
 def init_logging():
     fmt = "%(asctime)s.%(msecs)03d %(levelname)5s %(process)d --- [%(threadName)-15s] %(name)-30s: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
-    if os.path.exists("/mnt/hostfs"):
+    if os.path.exists("/mnt/hostfs/tmp"):
         logfile = "/mnt/hostfs/tmp/xud-docker.log"
     else:
         logfile = "xud-docker.log"

--- a/images/utils/launcher/__init__.py
+++ b/images/utils/launcher/__init__.py
@@ -1,17 +1,18 @@
 import logging
 import shlex
 import traceback
+import os.path
 
-from .config import Config, ConfigLoader
-from .shell import Shell
-from .node import NodeManager, NodeNotFound
-from .utils import ParallelExecutionError, ArgumentError
+from launcher.config import Config, ConfigLoader
+from launcher.shell import Shell
+from launcher.node import NodeManager, NodeNotFound
+from launcher.utils import ParallelExecutionError, ArgumentError
 
-from .check_wallets import Action as CheckWalletsAction
-from .close_other_utils import Action as CloseOtherUtilsAction
-from .auto_unlock import Action as AutoUnlockAction
-from .warm_up import Action as WarmUpAction
-from .errors import FatalError, ConfigError, ConfigErrorScope
+from launcher.check_wallets import Action as CheckWalletsAction
+from launcher.close_other_utils import Action as CloseOtherUtilsAction
+from launcher.auto_unlock import Action as AutoUnlockAction
+from launcher.warm_up import Action as WarmUpAction
+from launcher.errors import FatalError, ConfigError, ConfigErrorScope
 
 
 HELP = """\
@@ -97,7 +98,12 @@ Boltzcli shortcut commands
 def init_logging():
     fmt = "%(asctime)s.%(msecs)03d %(levelname)5s %(process)d --- [%(threadName)-15s] %(name)-30s: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.INFO, filename="/mnt/hostfs/tmp/xud-docker.log", filemode="w")
+    if os.path.exists("/mnt/hostfs"):
+        logfile = "/mnt/hostfs/tmp/xud-docker.log"
+    else:
+        logfile = "xud-docker.log"
+
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.INFO, filename=logfile, filemode="w")
 
     level_config = {
         "launcher": logging.DEBUG,

--- a/images/utils/launcher/check_wallets.py
+++ b/images/utils/launcher/check_wallets.py
@@ -97,7 +97,7 @@ class Action:
             c: Container = client.containers.get(name)
             cmd = f"lncli -n {network} -c {chain} getinfo"
             exit_code, output = c.exec_run(cmd)
-            self.logger.debug("[Execute] %s: exit_code=%s, output=%s", cmd, exit_code, output)
+            self.logger.debug("[Execute] %s: exit_code=%s\n%s", cmd, exit_code, output.decode())
 
             if exit_code == 0:
                 self.logger.debug("Skip restarting %s", name)
@@ -119,7 +119,7 @@ class Action:
             self.logger.debug("Sleep 15 seconds. For God's sake may %s work normally!!!", short_name)
             time.sleep(15)
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
+        with ThreadPoolExecutor(max_workers=3, thread_name_prefix="RestartLnd") as executor:
             f1 = executor.submit(lnd_restart, "bitcoin")
             f2 = executor.submit(lnd_restart, "litecoin")
 
@@ -223,7 +223,7 @@ class Action:
         cmd = f"lncli -n {network} -c {chain} getinfo"
         try:
             exit_code, output = lnd.exec_run(cmd)
-            self.logger.debug("[Execute] %s: exit_code=%s, output=%s", cmd, exit_code, output)
+            self.logger.debug("[Execute] %s: exit_code=%s\n%s", cmd, exit_code, output.decode())
         except:
             self.logger.exception("Failed to exec \"%s\" in container %s", cmd, name)
             return False
@@ -261,7 +261,7 @@ class Action:
         # xud is locked, run 'xucli unlock', 'xucli create', or 'xucli restore' then try again
         while True:
             exit_code, output = xud.exec_run(cmd)
-            self.logger.debug("[Execute] %s: exit_code=%s, output=%s", cmd, exit_code, output)
+            self.logger.debug("[Execute] %s: exit_code=%s\n%s", cmd, exit_code, output.decode())
             if exit_code == 0:
                 xud_ok = True
                 break
@@ -287,7 +287,7 @@ class Action:
                 print("Syncing light clients:")
                 self._print_lnd_cfheaders(erase_last_line=False)
 
-        with ThreadPoolExecutor(max_workers=2) as executor:
+        with ThreadPoolExecutor(max_workers=2, thread_name_prefix="LndReady") as executor:
             f1 = executor.submit(self.ensure_lnd_ready, "bitcoin")
             f2 = executor.submit(self.ensure_lnd_ready, "litecoin")
 

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -1007,15 +1007,15 @@ class Config:
                 if node in ["bitcoind", "litecoind"]:
                     dump_node_attr(node, "external_rpc_host")
                     dump_node_attr(node, "external_rpc_port")
-                    dump_node_attr(node, "external_rpc_user")
-                    dump_node_attr(node, "external_rpc_password")
+                    #dump_node_attr(node, "external_rpc_user")
+                    #dump_node_attr(node, "external_rpc_password")
                     dump_node_attr(node, "external_zmqpubrawblock")
                     dump_node_attr(node, "external_zmqpubrawtx")
                 elif node == "geth":
                     dump_node_attr(node, "external_rpc_host")
                     dump_node_attr(node, "external_rpc_port")
-                    dump_node_attr(node, "infura_project_id")
-                    dump_node_attr(node, "infura_project_secret")
+                    #dump_node_attr(node, "infura_project_id")
+                    #dump_node_attr(node, "infura_project_secret")
                     dump_node_attr(node, "cache")
                 elif node == "arby":
                     dump_node_attr(node, "test_centralized_baseasset_balance")
@@ -1026,6 +1026,6 @@ class Config:
                     dump_node_attr(node, "cex_quote_asset")
                     dump_node_attr(node, "live_cex")
                     dump_node_attr(node, "cex")
-                    dump_node_attr(node, "cex_api_key")
-                    dump_node_attr(node, "cex_api_secret")
+                    #dump_node_attr(node, "cex_api_key")
+                    #dump_node_attr(node, "cex_api_secret")
                     dump_node_attr(node, "margin")

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -54,6 +54,21 @@ class PortPublish:
             return False
         return True
 
+    def __str__(self):
+        if self.host:
+            host = "{}:{}".format(self.host, self.host_port)
+        else:
+            host = "{}".format(self.host_port)
+
+        container = "{}".format(self.port)
+
+        if self.protocol == "tcp":
+            return "{}:{}".format(host, container)
+        elif self.protocol == "udp":
+            return "{}:{}/udp".format(host, container)
+        elif self.protocol == "sctp":
+            return "{}:{}/sctp".format(host, container)
+
 
 nodes_config = {
     "simnet": {

--- a/images/utils/launcher/node/__init__.py
+++ b/images/utils/launcher/node/__init__.py
@@ -217,26 +217,20 @@ class NodeManager:
         elif status == "disabled_with_container":
             return "remove"
 
-    def _readable_details(self, details):
-        if not details:
-            return None
-        diff_keys = [key for key, value in details.items() if not value.same]
-        return ", ".join(diff_keys)
-
     def update(self) -> bool:
         if self.config.disable_update:
+            self.logger.info("Disable update checking")
             return True
 
+        self.logger.info("Checking for updates")
+        print("🌍 Checking for updates...")
+
+        # Checking for image updates
+        self.logger.info("Checking for image updates")
         outdated = False
         image_outdated = False
-
-        # Step 1. check all images
-        print("🌍 Checking for updates...")
         images = self.image_manager.check_for_updates()
 
-        self.logger.debug("[Update] Image checking result: %r", images)
-
-        # TODO handle image local status. Print a warning or give users a choice
         for image in images:
             status = image.status
             if status in ["LOCAL_MISSING", "LOCAL_OUTDATED"]:
@@ -247,25 +241,31 @@ class NodeManager:
                 all_unavailable_images = [x.name for x in images if x.status == "UNAVAILABLE"]
                 raise FatalError("Image(s) not found: %s" % ", ".join(all_unavailable_images))
 
-        # Step 2. check all containers
+        # Checking for container updates
+        self.logger.info("Checking for container updates")
         containers = self.nodes.values()
         container_check_result = {c: None for c in containers}
 
         def print_failed(failed):
-            print("Failed to check for container updates.")
-            for container, error in failed:
-                print("- {}: {}".format(container.name, get_useful_error_message(error)))
+            pass
 
         def try_again():
-            answer = self.shell.yes_or_no("Try again?")
-            return answer == "yes"
+            return False
 
         def handle_result(container, result):
             container_check_result[container] = result
 
-        parallel_execute(containers, lambda c: c.check_for_updates(), 60, print_failed, try_again, handle_result)
+        def wrapper(c):
+            self.logger.info("(%s) Checking for updates", c.container_name)
+            try:
+                status, details = c.check_for_updates()
+                self.logger.info("(%s) Checking for updates: %s", c.container_name, status)
+                return status, details
+            except Exception as e:
+                self.logger.exception("(%s) Checking for updates: ERRORED", c.container_name)
+                raise e
 
-        self.logger.debug("[Update] Container checking result: %r", container_check_result)
+        parallel_execute(containers, lambda c: wrapper(c), 30, print_failed, try_again, handle_result)
 
         for container, result in container_check_result.items():
             status, details = result
@@ -274,11 +274,7 @@ class NodeManager:
             # when disabled False -> True, status will be "disabled_with_container"
             # when disabled True -> False, status will be "missing" because we deleted the container before
             if status in ["missing", "outdated", "external_with_container", "disabled_with_container"]:
-                readable_details = self._readable_details(details)
-                if readable_details:
-                    print("- Container %s: %s (%s)" % (container.container_name, self._display_container_status_text(status), readable_details))
-                else:
-                    print("- Container %s: %s" % (container.container_name, self._display_container_status_text(status)))
+                print("- Container %s: %s" % (container.container_name, self._display_container_status_text(status)))
                 outdated = True
 
         if not outdated:

--- a/images/utils/launcher/node/geth.py
+++ b/images/utils/launcher/node/geth.py
@@ -97,7 +97,7 @@ class Geth(Node):
         timeout = 30
         min_delay = timedelta(seconds=timeout)
         provider = None
-        with ThreadPoolExecutor(max_workers=len(providers)) as executor:
+        with ThreadPoolExecutor(max_workers=len(providers), thread_name_prefix="GethProvider") as executor:
             fs = {executor.submit(self.get_provider_delay, p): p for p in providers}
             done, not_done = wait(fs, timeout)
             for f in done:


### PR DESCRIPTION
This PR dumps all configurations as `network_dir/logs/config.sh` on every launch. The dump file could be used to distinguish disabled services and missing containers.

### How to test?

```bash
bash xud.sh -b dump-config
cat ~/.xud-docker/{simnet,testnet,mainnet}/logs/config.sh
```