### PR TITLE
chore: upgrade alpine 3.11 -> 3.12, go1.13 -> go1.14

### DIFF
--- a/images/arby/Dockerfile
+++ b/images/arby/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:12-alpine3.11 AS builder
+FROM node:12-alpine3.12 AS builder
 RUN apk add --no-cache git bash
 WORKDIR /arby
 ADD .src .
 RUN npm install
 
-FROM node:12-alpine3.11
+FROM node:12-alpine3.12
 RUN apk add --no-cache bash supervisor curl rsync
 RUN mkdir /root/.arby
 VOLUME [ "/root/.arby" ]

--- a/images/bitcoind/Dockerfile
+++ b/images/bitcoind/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as builder
+FROM alpine:3.12 as builder
 RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boost-dev libevent-dev zeromq-dev
 WORKDIR /bitcoin
 ADD .src .
@@ -9,7 +9,7 @@ RUN make install
 RUN strip /usr/local/bin/bitcoind /usr/local/bin/bitcoin-cli
 
 
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk --no-cache add boost-system boost-filesystem boost-chrono boost-thread libevent zeromq bash
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoin-cli /usr/local/bin/
 ENTRYPOINT ["bitcoind"]

--- a/images/bitcoind/Dockerfile
+++ b/images/bitcoind/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boo
 WORKDIR /bitcoin
 ADD .src .
 RUN ./autogen.sh
-RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs --disable-wallet
+RUN ./configure --disable-ccache --disable-tests --disable-bench --without-gui --with-daemon --with-utils --without-libs --disable-wallet --enable-endomorphism
 RUN make -j$(nproc)
 RUN make install
 RUN strip /usr/local/bin/bitcoind /usr/local/bin/bitcoin-cli

--- a/images/boltz/Dockerfile
+++ b/images/boltz/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine3.11 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache bash git make gcc libc-dev
 WORKDIR $GOPATH/src/github.com/BoltzExchange/boltz-lnd
 ADD .src .
@@ -6,7 +6,7 @@ RUN go mod vendor
 RUN make install
 
 # Final stage
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk add --no-cache bash expect supervisor tor
 COPY --from=builder /go/bin/boltzd /go/bin/boltzcli /usr/local/bin/
 COPY --from=builder /go/src/github.com/BoltzExchange/boltz-lnd/example/config.toml /sample-config.toml

--- a/images/connext/Dockerfile
+++ b/images/connext/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:12-alpine3.11 AS builder
+FROM node:12-alpine3.12 AS builder
 RUN apk add --no-cache git bash python3 make g++ python
 WORKDIR /connext
 ADD .src .
 RUN npm install
 RUN npm run build
 
-FROM node:12-alpine3.11
+FROM node:12-alpine3.12
 RUN apk add --no-cache bash supervisor curl
 RUN mkdir /root/.connext
 COPY --from=builder /connext /app

--- a/images/connext/Dockerfile
+++ b/images/connext/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:12-alpine3.12 AS builder
-RUN apk add --no-cache git bash python3 make g++ python
+RUN apk add --no-cache git bash python3 make g++ python2
 WORKDIR /connext
 ADD .src .
 RUN npm install

--- a/images/geth/Dockerfile
+++ b/images/geth/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.14-alpine as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 RUN apk add --no-cache alpine-sdk
 WORKDIR /go-ethereum
 ADD .src .
 RUN make geth
 
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk add --no-cache ca-certificates bash
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 COPY entrypoint.sh rinkeby-peers.txt mainnet-peers.txt /

--- a/images/litecoind/Dockerfile
+++ b/images/litecoind/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as builder
+FROM alpine:3.12 as builder
 RUN apk --no-cache add musl-dev g++ make autoconf automake libtool pkgconfig boost-dev libressl-dev libevent-dev zeromq-dev
 WORKDIR /litecoin
 ADD .src .
@@ -13,7 +13,7 @@ RUN make install
 RUN strip /usr/local/bin/litecoind /usr/local/bin/litecoin-cli
 
 
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk --no-cache add boost-system boost-filesystem boost-chrono boost-thread libevent libressl zeromq bash
 COPY --from=builder /usr/local/bin/litecoind /usr/local/bin/litecoin-cli /usr/local/bin/
 ADD entrypoint.sh /

--- a/images/lndbtc-simnet/Dockerfile
+++ b/images/lndbtc-simnet/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.14-alpine3.12 as builder
-RUN apk add --no-cache bash git make gcc musl-dev
+RUN apk add --no-cache bash git make gcc musl-dev patch
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 ADD .src .
 RUN go mod vendor

--- a/images/lndbtc-simnet/Dockerfile
+++ b/images/lndbtc-simnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.11 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache bash git make gcc musl-dev
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 ADD .src .
@@ -13,7 +13,7 @@ RUN go install -v -mod=vendor -tags="$TAGS" -ldflags "$LDFLAGS" ./cmd/lnd ./cmd/
 RUN strip /go/bin/lnd /go/bin/lncli
 
 
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk add --no-cache bash tor
 COPY --from=builder /go/bin/lnd /go/bin/lncli /usr/local/bin/
 COPY entrypoint.sh /entrypoint.sh

--- a/images/lndbtc/Dockerfile
+++ b/images/lndbtc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.11 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache bash git make gcc musl-dev
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 ADD .src .
@@ -8,7 +8,7 @@ RUN go install -v -tags="$TAGS" -ldflags "$LDFLAGS" ./cmd/lnd ./cmd/lncli
 RUN strip /go/bin/lnd /go/bin/lncli
 
 # Final stage
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk add --no-cache bash expect supervisor tor
 COPY --from=builder /go/bin/lnd /go/bin/lncli /usr/local/bin/
 COPY entrypoint.sh /entrypoint.sh

--- a/images/lndltc-simnet/Dockerfile
+++ b/images/lndltc-simnet/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.14-alpine3.12 as builder
-RUN apk add --no-cache bash git make gcc musl-dev
+RUN apk add --no-cache bash git make gcc musl-dev patch
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 ADD .src .
 RUN go mod vendor

--- a/images/lndltc-simnet/Dockerfile
+++ b/images/lndltc-simnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.11 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache bash git make gcc musl-dev
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 ADD .src .
@@ -13,7 +13,7 @@ RUN go install -v -mod=vendor -tags="$TAGS" -ldflags "$LDFLAGS" ./cmd/lnd ./cmd/
 RUN strip /go/bin/lnd /go/bin/lncli
 
 
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk add --no-cache bash tor
 COPY --from=builder /go/bin/lnd /go/bin/lncli /usr/local/bin/
 COPY entrypoint.sh /entrypoint.sh

--- a/images/lndltc/Dockerfile
+++ b/images/lndltc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.11 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache bash git make gcc musl-dev
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 ADD .src .
@@ -8,7 +8,7 @@ RUN go install -v -tags="$TAGS" -ldflags "$LDFLAGS" ./cmd/lnd ./cmd/lncli
 RUN strip /go/bin/lnd /go/bin/lncli
 
 # Final stage
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk add --no-cache bash expect supervisor tor
 COPY --from=builder /go/bin/lnd /go/bin/lncli /usr/local/bin/
 COPY entrypoint.sh /entrypoint.sh

--- a/images/utils/launcher/node/image.py
+++ b/images/utils/launcher/node/image.py
@@ -300,7 +300,7 @@ class ImageManager:
 
     def get_image(self, name: str, node: Node) -> Image:
         """Get Image object by name. The name cloud be like "alpine",
-        "alpine:3.11" or "exchangeunion/bitcoind:0.20.0". The same normalized
+        "alpine:3.12" or "exchangeunion/bitcoind:0.20.0". The same normalized
         name will always get the same Image object.
 
         The name normalization examples:

--- a/images/webui/Dockerfile
+++ b/images/webui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as builder
+FROM node:14-alpine3.12 as builder
 RUN apk --no-cache add git
 
 WORKDIR /src
@@ -14,7 +14,7 @@ RUN apk --no-cache add bash
 RUN yarn build
 
 
-FROM node:14-alpine
+FROM node:14-alpine3.12
 COPY --from=builder /src/backend/node_modules /app/node_modules
 COPY --from=builder /src/backend/dist /app/dist
 COPY --from=builder /src/backend/bin /app/bin

--- a/images/webui/Dockerfile.aarch64
+++ b/images/webui/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM node:14-alpine as builder
+FROM node:14-alpine3.12 as builder
 RUN apk --no-cache add git
 
 WORKDIR /src
@@ -16,7 +16,7 @@ RUN apk --no-cache add bash
 RUN yarn build
 
 
-FROM node:14-alpine
+FROM node:14-alpine3.12
 COPY --from=builder /src/backend/node_modules /app/node_modules
 COPY --from=builder /src/backend/dist /app/dist
 COPY --from=builder /src/backend/bin /app/bin

--- a/images/xud/Dockerfile
+++ b/images/xud/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine3.11 AS builder
+FROM node:12-alpine3.12 AS builder
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 WORKDIR /xud
 ADD .src .
@@ -12,7 +12,7 @@ RUN npm prune --production
 RUN rm -rf seedutil/go
 RUN strip seedutil/seedutil
 
-FROM node:12-alpine3.11
+FROM node:12-alpine3.12
 RUN apk add --no-cache bash tor
 COPY --from=builder /xud /app
 COPY entrypoint.sh update-backup-dir.sh xud-backup.sh /

--- a/images/xud/Dockerfile.aarch64
+++ b/images/xud/Dockerfile.aarch64
@@ -3,7 +3,7 @@ FROM node:12-alpine3.12 AS builder
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 # Pre-built binaries not found for sqlite3@4.1.0 and node@12.16.1 (node-v72 ABI, musl) (falling back to source compile with node-gyp)
 # python: not found
-RUN apk add --no-cache python
+RUN apk add --no-cache python2
 WORKDIR /xud
 ADD .src .
 ARG GIT_REVISION

--- a/images/xud/Dockerfile.aarch64
+++ b/images/xud/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM node:12-alpine3.11 AS builder
+FROM node:12-alpine3.12 AS builder
 # Use pure JS implemented secp256k1 bindings
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 # Pre-built binaries not found for sqlite3@4.1.0 and node@12.16.1 (node-v72 ABI, musl) (falling back to source compile with node-gyp)
@@ -19,7 +19,7 @@ RUN npm prune --production
 RUN rm -rf seedutil/go
 RUN strip seedutil/seedutil
 
-FROM node:12-alpine3.11
+FROM node:12-alpine3.12
 RUN apk add --no-cache bash tor
 COPY --from=builder /xud /app
 COPY entrypoint.sh update-backup-dir.sh xud-backup.sh /


### PR DESCRIPTION
Would want to wait with node.js upgrade to 14 until @sangaman  made sure xud is v14 compatible. Main reason for the upgrade to alpine 3.12 is the upgraded tor version.