### PR TITLE
tools: add ci label to images

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -47,7 +47,5 @@ jobs:
         with:
           python-version: '3.9'
           architecture: 'x64'
-      - name: Show Python version
-        run: python -c "import sys; print(sys.version)"
       - name: Build and push
         run: tools/push -p linux/arm64

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -52,7 +52,5 @@ jobs:
         with:
           python-version: '3.9'
           architecture: 'x64'
-      - name: Show Python version
-        run: python -c "import sys; print(sys.version)"
       - name: Build and push
         run: tools/push -p linux/arm64 ${{ github.event.inputs.images }}

--- a/tools/core/image.py
+++ b/tools/core/image.py
@@ -12,7 +12,7 @@ import threading
 
 from .docker import ManifestList
 from .src import SourceManager
-from .utils import execute
+from .utils import execute, get_github_job_url
 
 if TYPE_CHECKING:
     from .toolkit import Platform, Context
@@ -71,7 +71,7 @@ class Image:
     def get_labels(self, application_revision) -> List[str]:
         image_revision = ""
         image_source = ""
-        image_travis = ""
+        image_ci = ""
 
         if self.revision:
 
@@ -81,15 +81,17 @@ class Image:
                 source = "{}/blob/{}/images/{}/Dockerfile".format(self.context.project_repo, image_revision, self.name)
                 image_source = source
 
-        if "TRAVIS_BUILD_WEB_URL" in os.environ:
-            image_travis = os.environ["TRAVIS_BUILD_WEB_URL"]
+        if "GITHUB_RUN_ID" in os.environ:
+            run_id = os.environ["GITHUB_RUN_ID"]
+            job_name = os.environ["GITHUB_JOB"]
+            image_ci = get_github_job_url(run_id, job_name)
 
         prefix = self.label_prefix
 
         return [
             f"--label {prefix}.image.revision='{image_revision}'",
             f"--label {prefix}.image.source='{image_source}'",
-            f"--label {prefix}.image.travis='{image_travis}'",
+            f"--label {prefix}.image.ci='{image_ci}'",
             f"--label {prefix}.application.revision='{application_revision}'",
             # TODO remove labels below
             f"--label {prefix}.image.branch='master'",

--- a/tools/core/utils.py
+++ b/tools/core/utils.py
@@ -1,6 +1,19 @@
 from subprocess import check_output, STDOUT
+from urllib.request import urlopen
+import json
+from typing import Optional
 
 
 def execute(cmd: str) -> str:
     output = check_output(cmd, shell=True, stderr=STDOUT)
     return output.decode()
+
+
+def get_github_job_url(run_id: str, job_name: str) -> Optional[str]:
+    url = "https://api.github.com/repos/ExchangeUnion/xud-docker/actions/runs/{}/jobs".format(run_id)
+    resp = urlopen(url)
+    j = json.load(resp)
+    for job in j["jobs"]:
+        if job["name"] == job_name:
+            return "https://github.com/ExchangeUnion/xud-docker/runs/{}?check_suite_focus=true".format(job["id"])
+    return None


### PR DESCRIPTION
This PR adds `com.exchangeunion.image.ci` label to images built from GitHub actions. So the xud-docker-bot could tell the image build source like Travis.