### PR TITLE
feat(proxy): add ui dashboard app to proxy container

### DIFF
--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,14 +1,21 @@
 FROM golang:1.15-alpine3.12 as builder
-WORKDIR github.com/ExchangeUnion/xud-docker-api-poc
-COPY .src/go.mod .
-COPY .src/go.sum .
-RUN go mod download
+WORKDIR /src
 ADD .src .
+WORKDIR /src/backend
+RUN go mod download
 RUN go build ./cmd/proxy
 
+FROM node:14-alpine3.12 AS ui-builder
+WORKDIR /src
+ADD .src .
+WORKDIR /src/frontend
+RUN yarn install
+RUN yarn build
+
 FROM alpine:3.12
-COPY --from=builder /go/github.com/ExchangeUnion/xud-docker-api-poc/proxy /usr/local/bin/proxy
-COPY --from=builder /go/github.com/ExchangeUnion/xud-docker-api-poc/cmd/proxy/cert.sh .
 RUN apk add --update openssl
+COPY --from=builder /src/backend/proxy /usr/local/bin/proxy
+COPY --from=builder /src/backend/cmd/proxy/cert.sh .
+COPY --from=ui-builder /src/frontend/build ./ui
 ADD entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -1,13 +1,26 @@
 from tools.core import src
+import os
 
 
 class SourceManager(src.SourceManager):
     def __init__(self):
-        super().__init__("https://github.com/ExchangeUnion/xud-docker-api")
+        super().__init__(None)
+        self.frontend_dir = os.path.join(self.src_dir, "frontend")
+        self.backend_dir = os.path.join(self.src_dir, "backend")
 
-    def get_ref(self, version):
+    def ensure(self, version):
+        self.ensure_repo("https://github.com/ExchangeUnion/xud-ui-dashboard", self.frontend_dir)
+        self.ensure_repo("https://github.com/ExchangeUnion/xud-docker-api", self.backend_dir)
         if version == "latest":
-            # change "master" to a another xud branch for testing
-            return "master"
+            # change "master" or "main" to a another xud branch for testing
+            self.checkout_repo(self.frontend_dir, "main")
+            self.checkout_repo(self.backend_dir, "master")
         else:
-            return "v" + version
+            self.checkout_repo(self.frontend_dir, "v" + version)
+            self.checkout_repo(self.backend_dir, "v" + version)
+
+    def get_application_revision(self, version):
+        r1 = self.get_revision(self.frontend_dir)
+        r2 = self.get_revision(self.backend_dir)
+        return f"frontend:{r1},backend:{r2}"
+


### PR DESCRIPTION
This PR adds the functionality of serving the XUD Explorer Dashboard as a web application, independent of the the native Electron app, from the proxy container.
Closes https://github.com/ExchangeUnion/xud-ui/issues/94

How to test:
in `xud-docker` dir

```bash
git checkout feat/proxy-ui
```
edit `images/proxy/src.py` by replacing `"master"` with `"feat/ui"`. The frontend branch can remain as `"main"`.

```bash
./tools/build proxy:latest
./tools/build utils:latest
bash setup.sh -b feat/proxy-ui --proxy.disabled=false --dev --use-local-images proxy
```
Open `http://localhost:{port}` in the browser (the port is the usual proxy port 8889, 18889, 28889 depending on the network)