### PR TITLE
feat: upgrade arby to 1.3.1

### DIFF
--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -538,7 +538,7 @@ nodes_config = {
         },
         "arby": {
             "name": "arby",
-            "image": "exchangeunion/arby:1.3.0",
+            "image": "exchangeunion/arby:1.3.1",
             "volumes": [
                 {
                     "host": "$data_dir/arby",


### PR DESCRIPTION
This version upgrades arby to 1.3.1 which mitigates memory leakage by reducing the restart interval from 6 hours to 1 hour.