### PR TITLE
feat: add console api

### DIFF
--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -13,9 +13,8 @@ RUN yarn install
 RUN yarn build
 
 FROM alpine:3.12
-RUN apk add --update openssl
+RUN apk add --update openssl bash docker-cli
 COPY --from=builder /src/backend/proxy /usr/local/bin/proxy
-COPY --from=builder /src/backend/cmd/proxy/cert.sh .
 COPY --from=ui-builder /src/frontend/build ./ui
 ADD entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/images/proxy/entrypoint.sh
+++ b/images/proxy/entrypoint.sh
@@ -15,5 +15,9 @@ while [ ! -e /root/.lndltc/tls.cert ]; do
     sleep 3
 done
 
+if [ ! -e /root/.proxy/tls.cert ]; then
+    openssl req -newkey rsa:2048 -nodes -keyout /root/.proxy/tls.key -x509 -days 1095 -subj '/CN=localhost' -out /root/.proxy/tls.crt
+fi
+
 #shellcheck disable=2068
 exec proxy $@

--- a/images/proxy/entrypoint.sh
+++ b/images/proxy/entrypoint.sh
@@ -15,7 +15,7 @@ while [ ! -e /root/.lndltc/tls.cert ]; do
     sleep 3
 done
 
-if [ ! -e /root/.proxy/tls.cert ]; then
+if [ ! -e /root/.proxy/tls.crt ]; then
     openssl req -newkey rsa:2048 -nodes -keyout /root/.proxy/tls.key -x509 -days 1095 -subj '/CN=localhost' -out /root/.proxy/tls.crt
 fi
 

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -13,8 +13,8 @@ class SourceManager(src.SourceManager):
         self.ensure_repo("https://github.com/ExchangeUnion/xud-docker-api", self.backend_dir)
         if version == "latest":
             # change "master" or "main" to a another xud branch for testing
-            self.checkout_repo(self.frontend_dir, "main")
-            self.checkout_repo(self.backend_dir, "master")
+            self.checkout_repo(self.frontend_dir, "feat/console")
+            self.checkout_repo(self.backend_dir, "console")
         else:
             self.checkout_repo(self.frontend_dir, "v" + version)
             self.checkout_repo(self.backend_dir, "v" + version)

--- a/images/proxy/src.py
+++ b/images/proxy/src.py
@@ -13,8 +13,8 @@ class SourceManager(src.SourceManager):
         self.ensure_repo("https://github.com/ExchangeUnion/xud-docker-api", self.backend_dir)
         if version == "latest":
             # change "master" or "main" to a another xud branch for testing
-            self.checkout_repo(self.frontend_dir, "feat/console")
-            self.checkout_repo(self.backend_dir, "console")
+            self.checkout_repo(self.frontend_dir, "main")
+            self.checkout_repo(self.backend_dir, "master")
         else:
             self.checkout_repo(self.frontend_dir, "v" + version)
             self.checkout_repo(self.backend_dir, "v" + version)

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -175,6 +175,10 @@ nodes_config = {
                     "container": "/root/.lndltc",
                 },
                 {
+                    "host": "$data_dir/proxy",
+                    "container": "/root/.proxy",
+                },
+                {
                     "host": "$network_dir",
                     "container": "/root/network",
                 },
@@ -183,7 +187,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
-            "disabled": True,
+            "disabled": False,
         },
         "xud": {
             "name": "xud",
@@ -397,6 +401,10 @@ nodes_config = {
                     "container": "/root/.lndltc",
                 },
                 {
+                    "host": "$data_dir/proxy",
+                    "container": "/root/.proxy",
+                },
+                {
                     "host": "$network_dir",
                     "container": "/root/network",
                 },
@@ -405,7 +413,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
-            "disabled": True,
+            "disabled": False,
         },
         "xud": {
             "name": "xud",
@@ -618,6 +626,10 @@ nodes_config = {
                     "container": "/root/.lndltc",
                 },
                 {
+                    "host": "$data_dir/proxy",
+                    "container": "/root/.proxy",
+                },
+                {
                     "host": "$network_dir",
                     "container": "/root/network",
                 },
@@ -626,7 +638,7 @@ nodes_config = {
             "mode": "native",
             "preserve_config": False,
             "use_local_image": False,
-            "disabled": True,
+            "disabled": False,
         },
         "xud": {
             "name": "xud",


### PR DESCRIPTION
This PR bump proxy frontend to `feat/console` branch and backend to `console` branch to present the console view + api. And it also makes proxy container enabled by default.

### How to test?

```
bash xud.sh -b console
```

N.B. Use `mkcert` to trust your self-signed certificate

```bash
mkcert -install
mkcert localhost 127.0.0.1 ::1 -cert-file tls.crt -key-file tls.key
# copy it to your simnet proxy
sudo mkdir -p ~/.xud-docker/simnet/data/proxy
sudo cp tls.* ~/.xud-docker/simnet/data/proxy
```

EDIT by @kilrau : closes https://github.com/ExchangeUnion/xud-docker/issues/745
EDIT by @kilrau : closes https://github.com/ExchangeUnion/xud-ui/issues/29