### PR TITLE
chore: update boltz-lnd to v1.1.2

### DIFF
--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -565,7 +565,7 @@ nodes_config = {
         },
         "boltz": {
             "name": "boltz",
-            "image": "exchangeunion/boltz:1.1.1",
+            "image": "exchangeunion/boltz:1.1.2",
             "volumes": [
                 {
                     "host": "$data_dir/boltz",


### PR DESCRIPTION
Updates boltz-lnd to [v1.1.2](https://github.com/BoltzExchange/boltz-lnd/releases/tag/v1.1.2) which includes a fix to show the Swap ID in the `DepositResponse`