### PR TITLE
fix: KeyError when retrieving Labels

### DIFF
--- a/images/utils/launcher/docker/core.py
+++ b/images/utils/launcher/docker/core.py
@@ -151,12 +151,18 @@ class DockerUtility:
             digest = payload["config"]["digest"]
             resp = self.docker_registry_client.get_blob(name.repo, digest)
             blob = json.load(resp)
+
+            try:
+                labels = blob["config"]["Labels"] or {}
+            except KeyError:
+                labels = {}
+
             return Image(
                 repo=name.repo,
                 tag=name.tag,
                 digest=digest,
                 created_at=self._dt_parser.parse(blob["created"]),
-                labels=blob["config"]["Labels"] or {},
+                labels=labels,
                 layers=[Layer(digest=layer["digest"], size=layer["size"]) for layer in payload["layers"]]
             )
 


### PR DESCRIPTION
This is a hotfix for ARM when the error below happens

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/__init__.py", line 281, in launch
    env.start()
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/__init__.py", line 250, in start
    up_env = self.node_manager.update()
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/node/__init__.py", line 233, in update
    images = self.image_manager.check_for_updates()
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/node/image.py", line 178, in check_for_updates
    use, pull = f.result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/node/image.py", line 136, in _check_image
    cloud = self._get_cloud_image(image)
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/node/image.py", line 122, in _get_cloud_image
    image = self.dockerutil.get_image(name)
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/docker/core.py", line 77, in get_image
    return self._get_registry_image(name)
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/docker/core.py", line 128, in _get_registry_image
    return self._handle_v2_manifest(canonical_name, payload)
  File "/usr/local/lib/python3.8/site-packages/launcher-1.0.0-py3.8.egg/launcher/docker/core.py", line 159, in _handle_v2_manifest
    labels=blob["config"]["Labels"] or {},
KeyError: 'Labels'
```