### PR TITLE
chore: use node lts

### DIFF
--- a/images/arby/Dockerfile
+++ b/images/arby/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:12-alpine3.12 AS builder
+FROM node:lts-alpine3.12 AS builder
 RUN apk add --no-cache git bash
 WORKDIR /arby
 ADD .src .
 RUN npm install
 
-FROM node:12-alpine3.12
+FROM node:lts-alpine3.12
 RUN apk add --no-cache bash supervisor curl rsync
 RUN mkdir /root/.arby
 VOLUME [ "/root/.arby" ]

--- a/images/connext/Dockerfile
+++ b/images/connext/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:12-alpine3.12 AS builder
+FROM node:lts-alpine3.12 AS builder
 RUN apk add --no-cache git bash python3 make g++ python2
 WORKDIR /connext
 ADD .src .
 RUN npm install
 RUN npm run build
 
-FROM node:12-alpine3.12
+FROM node:lts-alpine3.12
 RUN apk add --no-cache bash supervisor curl
 RUN mkdir /root/.connext
 COPY --from=builder /connext /app

--- a/images/xud/Dockerfile
+++ b/images/xud/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine3.12 AS builder
+FROM node:lts-alpine3.12 AS builder
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 WORKDIR /xud
 ADD .src .
@@ -12,7 +12,7 @@ RUN npm prune --production
 RUN rm -rf seedutil/go
 RUN strip seedutil/seedutil
 
-FROM node:12-alpine3.12
+FROM node:lts-alpine3.12
 RUN apk add --no-cache bash tor
 COPY --from=builder /xud /app
 COPY entrypoint.sh update-backup-dir.sh xud-backup.sh /

--- a/images/xud/Dockerfile.aarch64
+++ b/images/xud/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM node:12-alpine3.12 AS builder
+FROM node:lts-alpine3.12 AS builder
 # Use pure JS implemented secp256k1 bindings
 RUN apk add --no-cache git rsync bash musl-dev go python3 make g++
 # Pre-built binaries not found for sqlite3@4.1.0 and node@12.16.1 (node-v72 ABI, musl) (falling back to source compile with node-gyp)
@@ -19,7 +19,7 @@ RUN npm prune --production
 RUN rm -rf seedutil/go
 RUN strip seedutil/seedutil
 
-FROM node:12-alpine3.12
+FROM node:lts-alpine3.12
 RUN apk add --no-cache bash tor
 COPY --from=builder /xud /app
 COPY entrypoint.sh update-backup-dir.sh xud-backup.sh /


### PR DESCRIPTION
This updates node versions to use lts instead of hardcoding at v12. Lts is currently v14 which supports ES2020 language features like `bigint`.

This is dependent on https://github.com/ExchangeUnion/xud/pull/2035 being merged, as currently the sqlite version we use does not build properly with node v14.