### PR TITLE
fix: boltz image after breaking gRPC changes

### DIFF
--- a/images/boltz/Dockerfile
+++ b/images/boltz/Dockerfile
@@ -17,4 +17,4 @@ COPY wrapper.sh /usr/bin/wrapper
 
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
-EXPOSE 9002 9003
+EXPOSE 9002 9003 9102 9103

--- a/images/boltz/entrypoint.sh
+++ b/images/boltz/entrypoint.sh
@@ -41,7 +41,7 @@ CERTPATH="/root/.$LNDDIR/tls.cert"
 MACAROONPATH="/root/.$LNDDIR/data/chain/$CHAIN/$NETWORK/admin.macaroon"
 
 write_config() {
-    echo "Creating new config for $CHAIN daemon"
+    echo "Creating config for $CHAIN daemon"
     mkdir -p $DATADIR
     cp /sample-config.toml $CONFIGFILE
 
@@ -60,6 +60,14 @@ write_config() {
     sed -i '/\[RPC/,/^$/s/restHost.*/restHost = "0.0.0.0"/' $CONFIGFILE
     sed -i "/\[RPC/,/^$/s/restPort.*/restPort = $RESTPORT/" $CONFIGFILE
 }
+
+# Config file migration
+# If the config file does *not* contain anything related to the REST proxy of boltz-lnd,
+# it is safe to assume that it is oudated and needs to be recreated
+if [[ -e $CONFIGFILE ]] && ! grep -q "rest" "$CONFIGFILE"; then
+    echo "Removing outdated config file"
+    rm $CONFIGFILE
+fi
 
 if [[ $REWRITE_CONFIG || ! -e $CONFIGFILE ]]; then
 	write_config

--- a/images/boltz/entrypoint.sh
+++ b/images/boltz/entrypoint.sh
@@ -6,6 +6,9 @@ DATADIR="/root/.boltz/$CHAIN"
 LOGFILE="$DATADIR/boltz.log"
 CONFIGFILE="$DATADIR/boltz.conf"
 DATABASEFILE="$DATADIR/boltz.db"
+ADMINMACAROONFILE="$DATADIR/admin.macaroon"
+TLSKEYFILE="$DATADIR/tls.key"
+TLSCERTFILE="$DATADIR/tls.cert"
 
 case "$CHAIN" in
     "bitcoin")
@@ -15,6 +18,7 @@ case "$CHAIN" in
         LNDHOST="lndbtc"
 
         PORT="9002"
+        RESTPORT="9003"
         ;;
 
     "litecoin")
@@ -23,7 +27,8 @@ case "$CHAIN" in
         LNDDIR="lndltc"
         LNDHOST="lndltc"
 
-        PORT="9003"
+        PORT="9102"
+        RESTPORT="9103"
         ;;
 
     *)
@@ -51,6 +56,9 @@ write_config() {
 
     sed -i '/\[RPC/,/^$/s/host.*/host = "0.0.0.0"/' $CONFIGFILE
     sed -i "/\[RPC/,/^$/s/port.*/port = $PORT/" $CONFIGFILE
+
+    sed -i '/\[RPC/,/^$/s/restHost.*/restHost = "0.0.0.0"/' $CONFIGFILE
+    sed -i "/\[RPC/,/^$/s/restPort.*/restPort = $RESTPORT/" $CONFIGFILE
 }
 
 if [[ $REWRITE_CONFIG || ! -e $CONFIGFILE ]]; then
@@ -70,4 +78,4 @@ echo 'Detecting localnet IP for lndltc...'
 LNDLTC_IP=$(getent hosts lndltc | awk '{ print $1 }')
 echo "$LNDLTC_IP lndltc" >> /etc/hosts
 
-exec boltzd --configfile $CONFIGFILE --logfile $LOGFILE --database.path $DATABASEFILE
+exec boltzd --configfile $CONFIGFILE --logfile $LOGFILE --database.path $DATABASEFILE --rpc.adminmacaroonpath $ADMINMACAROONFILE --rpc.tlscert $TLSCERTFILE --rpc.tlskey $TLSKEYFILE

--- a/images/boltz/wrapper.sh
+++ b/images/boltz/wrapper.sh
@@ -3,14 +3,16 @@
 CHAIN=$1
 
 # Use "${<variable>,,}" to convert the CHAIN variable to lower case
-# Reference: https://stackoverflow.com/a/2264537 
+# Reference: https://stackoverflow.com/a/2264537
 case "${CHAIN,,}" in
     "btc")
         PORT="9002"
+        DATADIR="/root/.boltz/bitcoin"
         ;;
 
     "ltc")
-        PORT="9003"
+        PORT="9102"
+        DATADIR="/root/.boltz/litecoin"
         ;;
 
     # Print the help command
@@ -28,4 +30,7 @@ case "${CHAIN,,}" in
         ;;
 esac
 
-exec boltzcli --port $PORT ${@:2}
+TLSCERT="$DATADIR/tls.cert"
+MACAROON="$DATADIR/admin.macaroon"
+
+exec boltzcli --port $PORT --tlscert $TLSCERT --macaroon $MACAROON ${@:2}

--- a/images/utils/launcher/config/config.py
+++ b/images/utils/launcher/config/config.py
@@ -1058,7 +1058,7 @@ class Config:
                 rpc["type"] = "gRPC"
                 rpc["host"] = "boltz"
                 rpc["btcPort"] = 9002
-                rpc["ltcPort"] = 9003
+                rpc["ltcPort"] = 9102
             elif name == "webui":
                 pass
 

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -533,7 +533,7 @@ nodes_config = {
         },
         "boltz": {
             "name": "boltz",
-            "image": "exchangeunion/boltz:1.1.2",
+            "image": "exchangeunion/boltz:1.2.0",
             "volumes": [
                 {
                     "host": "$data_dir/boltz",


### PR DESCRIPTION
This PR fixes the boltz-lnd integration because it was broken in the latest couple commits merged into master. These commits:

- added TLS to the gRPC interface
- added macaroon authentication to the gRPC interface
- added a REST proxy for the gRPC interface

Todo:

- [x] ~add `--datadir` argument for `boltzd` and `boltzcli` to make specifying the base directory to which boltzd writes files easier~ will be done in a separate PR
- [x] fix existing environments that were bricked with the new image