### PR TITLE
chore: update boltz image to v1.2.2

### DIFF
--- a/images/boltz/Dockerfile
+++ b/images/boltz/Dockerfile
@@ -10,7 +10,6 @@ RUN make install COMMIT=$GIT_REVISION
 FROM alpine:3.12
 RUN apk add --no-cache bash expect supervisor tor
 COPY --from=builder /go/bin/boltzd /go/bin/boltzcli /usr/local/bin/
-COPY --from=builder /go/src/github.com/BoltzExchange/boltz-lnd/example/config.toml /sample-config.toml
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY entrypoint.sh /
 COPY wrapper.sh /usr/bin/wrapper

--- a/images/boltz/wrapper.sh
+++ b/images/boltz/wrapper.sh
@@ -30,7 +30,4 @@ case "${CHAIN,,}" in
         ;;
 esac
 
-TLSCERT="$DATADIR/tls.cert"
-MACAROON="$DATADIR/admin.macaroon"
-
-exec boltzcli --port $PORT --tlscert $TLSCERT --macaroon $MACAROON ${@:2}
+exec boltzcli --port $PORT --datadir $DATADIR ${@:2}

--- a/images/utils/launcher/config/template.py
+++ b/images/utils/launcher/config/template.py
@@ -533,7 +533,7 @@ nodes_config = {
         },
         "boltz": {
             "name": "boltz",
-            "image": "exchangeunion/boltz:1.2.0",
+            "image": "exchangeunion/boltz:1.2.2",
             "volumes": [
                 {
                     "host": "$data_dir/boltz",


### PR DESCRIPTION
This PR updates `boltz-lnd` to [v1.2.2](https://github.com/BoltzExchange/boltz-lnd/releases/tag/v1.2.2). In [v1.2.1](https://github.com/BoltzExchange/boltz-lnd/releases/tag/v1.2.1) and [v1.2.2](https://github.com/BoltzExchange/boltz-lnd/releases/tag/v1.2.2) there were no major changes but I removed the sample config from the repository and added the `--datadir` flag which should make the scripts in the container a little bit simpler.

@reliveyy I moved the macaroons (there are two now; admin and readonly) to a new folder: `$BOLTZ_DATADIR/macaroons`