### PR TITLE
refactor: npm install --production for xud

### DIFF
--- a/images/xud/Dockerfile
+++ b/images/xud/Dockerfile
@@ -5,10 +5,11 @@ ADD .src .
 ARG GIT_REVISION
 RUN echo "" > parseGitCommit.js
 RUN echo "export default '-$GIT_REVISION';" > lib/Version.ts
-RUN npm install
+RUN npm install --production
+RUN npm install typescript --no-shrinkwrap
 RUN npm run compile
 RUN npm run compile:seedutil
-RUN npm prune --production
+RUN npm prune production
 RUN rm -rf seedutil/go
 RUN strip seedutil/seedutil
 

--- a/images/xud/Dockerfile.aarch64
+++ b/images/xud/Dockerfile.aarch64
@@ -9,13 +9,11 @@ ADD .src .
 ARG GIT_REVISION
 RUN echo "" > parseGitCommit.js
 RUN echo "export default '-$GIT_REVISION';" > lib/Version.ts
-RUN cp package.json /tmp/package.json
-RUN sed -i '/"grpc-tools"/d' package.json
-RUN npm install
-RUN cp /tmp/package.json package.json
+RUN npm install --production
+RUN npm install typescript --no-shrinkwrap
 RUN npm run compile
 RUN npm run compile:seedutil
-RUN npm prune --production
+RUN npm prune production
 RUN rm -rf seedutil/go
 RUN strip seedutil/seedutil
 


### PR DESCRIPTION
Follow-up to #840 - this installs xud with the `production` flag to avoid installing unnecessary `devDependencies`. 